### PR TITLE
fix: 行情/数据采集健壮性批量整治(P0–P3)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1336,11 +1336,15 @@ if os.path.exists(static_dir):
 if __name__ == "__main__":
     print("盯盘侠启动: http://127.0.0.1:8000")
     print("API 文档: http://127.0.0.1:8000/docs")
+    # 生产(Docker `python server.py`)不应开 reload:uvicorn 文件监听会多起一个 reloader
+    # 子进程、浪费资源,且监听 data/ 写入易误触发重启。本地热重载用 `make dev-api`
+    # (uvicorn --reload),或显式设 DEV_RELOAD=1。
+    _dev_reload = os.environ.get("DEV_RELOAD", "").lower() in ("1", "true", "yes")
     uvicorn.run(
         "server:app",
         host="0.0.0.0",
         port=8000,
-        reload=True,
-        reload_dirs=["src", "."],
-        reload_excludes=["data/*", "frontend/*", ".claude/*"],
+        reload=_dev_reload,
+        reload_dirs=["src", "."] if _dev_reload else None,
+        reload_excludes=["data/*", "frontend/*", ".claude/*"] if _dev_reload else None,
     )

--- a/src/collectors/akshare_collector.py
+++ b/src/collectors/akshare_collector.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import httpx
 
+from src.collectors.market_http import TTLCache, market_get
 from src.core.cn_symbol import get_cn_prefix
 from src.models.market import MarketCode, StockData, IndexData
 
@@ -12,6 +13,11 @@ logger = logging.getLogger(__name__)
 
 # 腾讯股票行情 API（HTTP，GBK 编码）
 TENCENT_QUOTE_URL = "http://qt.gtimg.cn/q="
+
+# 实时报价短 TTL 缓存 + 按 host 节流:平抑模拟盘/价格提醒每 60s 的批量并发突发。
+_QUOTE_HOST = "qt.gtimg.cn"
+_QUOTE_MIN_INTERVAL_S = 0.15
+_QUOTE_CACHE = TTLCache(default_ttl_sec=5.0)
 
 # 预定义指数
 CN_INDICES = [
@@ -103,6 +109,9 @@ def _parse_tencent_line(line: str) -> dict | None:
             circulating_market_value = _to_float(parts[44])
             total_market_value = _to_float(parts[45])
 
+        # 量比在 parts[49](腾讯行情字段)。价格提醒直接用它,免再拉 K线算 5 日均量。
+        volume_ratio = _to_float(parts[49]) if len(parts) > 49 else None
+
         return {
             "name": parts[1],
             "symbol": symbol,
@@ -116,6 +125,7 @@ def _parse_tencent_line(line: str) -> dict | None:
             "low_price": float(parts[34] or 0),
             "turnover": turnover,
             "turnover_rate": turnover_rate,
+            "volume_ratio": volume_ratio,
             "pe_ratio": pe_ratio,
             "circulating_market_value": circulating_market_value,
             "total_market_value": total_market_value,
@@ -126,19 +136,38 @@ def _parse_tencent_line(line: str) -> dict | None:
 
 
 def _fetch_tencent_quotes(symbols: list[str]) -> list[dict]:
-    """批量获取腾讯实时行情"""
+    """批量获取腾讯实时行情(直连 + 按 host 节流 + 退避重试 + 短TTL缓存)。"""
     if not symbols:
         return []
-    url = TENCENT_QUOTE_URL + ",".join(symbols)
-    with httpx.Client(trust_env=False) as client:  # 行情直连,绕过 env 代理
-        resp = client.get(url, timeout=10)
-        content = resp.content.decode("gbk", errors="ignore")
+    cache_key = ",".join(symbols)
+    cached = _QUOTE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    content = market_get(
+        TENCENT_QUOTE_URL + cache_key,
+        host_key=_QUOTE_HOST,
+        min_interval_s=_QUOTE_MIN_INTERVAL_S,
+        timeout=10,
+        retries=2,
+        parse="content",  # GBK,手动解码
+        log_label="腾讯报价",
+    )
+    if not content:
+        return []
+    text = (
+        content.decode("gbk", errors="ignore")
+        if isinstance(content, (bytes, bytearray))
+        else str(content)
+    )
 
     results = []
-    for line in content.strip().split(";"):
+    for line in text.strip().split(";"):
         parsed = _parse_tencent_line(line)
         if parsed and parsed["current_price"] > 0:
             results.append(parsed)
+    if results:
+        _QUOTE_CACHE.set(cache_key, results)
     return results
 
 

--- a/src/collectors/capital_flow_collector.py
+++ b/src/collectors/capital_flow_collector.py
@@ -3,8 +3,7 @@ import logging
 import time
 from dataclasses import dataclass
 
-import httpx
-
+from src.collectors.market_http import TTLCache, market_get, source_suffix
 from src.core.cn_symbol import is_cn_sh
 from src.models.market import MarketCode
 
@@ -12,6 +11,11 @@ logger = logging.getLogger(__name__)
 
 # 东方财富资金流向 API
 EASTMONEY_FLOW_URL = "https://push2his.eastmoney.com/api/qt/stock/fflow/daykline/get"
+
+# 资金流为日级数据、变动慢:中等 TTL 缓存 + 按 host 节流,避免直连调用每轮重复拉。
+_FLOW_HOST = "push2his.eastmoney.com"
+_FLOW_MIN_INTERVAL_S = 0.2
+_FLOW_CACHE = TTLCache(default_ttl_sec=600.0)
 
 
 @dataclass
@@ -58,7 +62,12 @@ class CapitalFlowCollector:
         self.market = market
 
     def get_capital_flow(self, symbol: str) -> CapitalFlow | None:
-        """获取单只股票的资金流向"""
+        """获取单只股票的资金流向(直连 + 节流 + 退避重试 + TTL缓存)。"""
+        cache_key = f"{self.market.value}:{symbol}"
+        cached = _FLOW_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         secid = _get_eastmoney_secid(symbol, self.market)
 
         params = {
@@ -76,13 +85,22 @@ class CapitalFlowCollector:
             "Referer": "https://quote.eastmoney.com/",
         }
 
-        try:
-            with httpx.Client(
-                follow_redirects=True, timeout=8, trust_env=False
-            ) as client:  # 行情直连,绕过 env 代理(生产代理会拦 push2his.eastmoney)
-                resp = client.get(EASTMONEY_FLOW_URL, params=params, headers=headers)
-                data = resp.json()
+        data = market_get(
+            EASTMONEY_FLOW_URL,
+            host_key=_FLOW_HOST,
+            params=params,
+            headers=headers,
+            min_interval_s=_FLOW_MIN_INTERVAL_S,
+            timeout=8,
+            retries=2,
+            parse="json",
+            symbol=symbol,
+            log_label="资金流",
+        )
+        if not data:
+            return None
 
+        try:
             if data.get("data") is None:
                 logger.warning(f"没有 data 数据 获取 {symbol} 资金流向失败: 无数据")
                 return None
@@ -135,10 +153,11 @@ class CapitalFlowCollector:
             # print(f"小单净流入: {capital_flow.small_net_inflow:,.2f} 元")
             # print(f"5日主力净流入: {capital_flow.main_net_5d:,.2f} 元")
 
+            _FLOW_CACHE.set(cache_key, capital_flow)
             return capital_flow
 
         except Exception as e:
-            logger.error(f"获取 {symbol} 资金流向失败: {e}")
+            logger.error(f"解析 {symbol} 资金流向失败: {e}{source_suffix()}")
             return None
 
     def get_capital_flow_summary(self, symbol: str) -> dict:

--- a/src/collectors/discovery_collector.py
+++ b/src/collectors/discovery_collector.py
@@ -3,8 +3,12 @@ from dataclasses import dataclass
 
 import httpx
 
+from src.collectors.market_http import TTLCache, source_suffix
 
 logger = logging.getLogger(__name__)
+
+# 异动/热门榜单为盘中分钟级数据:短 TTL 缓存,避免市场扫描重复拉。
+_DISCOVERY_CACHE = TTLCache(default_ttl_sec=90.0)
 
 
 @dataclass(frozen=True)
@@ -192,6 +196,11 @@ class EastMoneyDiscoveryCollector:
         return result
 
     async def _get_json(self, url: str, *, params: dict) -> dict:
+        cache_key = f"{url}?{sorted((params or {}).items())}"
+        cached = _DISCOVERY_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         headers = {
             "User-Agent": (
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -218,7 +227,9 @@ class EastMoneyDiscoveryCollector:
                 ) as client:
                     resp = await client.get(url, params=params)
                     resp.raise_for_status()
-                    return resp.json()
+                    data = resp.json()
+                    _DISCOVERY_CACHE.set(cache_key, data)
+                    return data
             except Exception as e:
                 last_exc = e
                 if attempt < attempts - 1:
@@ -232,6 +243,6 @@ class EastMoneyDiscoveryCollector:
 
         if last_exc is not None:
             logger.warning(
-                f"EastMoney discovery request failed: {type(last_exc).__name__}: {last_exc!r}"
+                f"EastMoney discovery request failed: {type(last_exc).__name__}: {last_exc!r}{source_suffix()}"
             )
         return {}

--- a/src/collectors/discovery_collector.py
+++ b/src/collectors/discovery_collector.py
@@ -212,7 +212,7 @@ class EastMoneyDiscoveryCollector:
                     timeout=timeout,
                     verify=self.verify_ssl,
                     follow_redirects=True,
-                    trust_env=True,
+                    trust_env=False,  # 不吃 env 代理(Telegram/AI 用),仅用显式配置的 self.proxy
                     headers=headers,
                     proxy=self.proxy,
                 ) as client:

--- a/src/collectors/events_collector.py
+++ b/src/collectors/events_collector.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 import httpx
 
+from src.collectors.market_http import source_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +182,7 @@ class EastMoneyEventsCollector:
 
         if last_exc is not None:
             self.last_error = f"{type(last_exc).__name__}: {last_exc!r}"
-            logger.warning(f"EastMoney 事件采集失败: {self.last_error}")
+            logger.warning(f"EastMoney 事件采集失败: {self.last_error}{source_suffix()}")
         return []
 
     def _parse_item(self, item: dict, stock_codes: list[str]) -> EventItem | None:

--- a/src/collectors/kline_collector.py
+++ b/src/collectors/kline_collector.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import contextvars
 import logging
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -14,6 +12,7 @@ import random
 import threading
 import time
 
+from src.collectors.market_http import fetch_source, source_suffix
 from src.core.cn_symbol import get_cn_prefix, is_cn_sh
 from src.models.market import MARKETS, MarketCode
 
@@ -30,28 +29,10 @@ _EASTMONEY_CACHE: dict[str, tuple[float, int, list["KlineData"]]] = {}
 _EASTMONEY_CACHE_TTL_SECONDS = 300
 
 
-# ── 调用来源标记 ───────────────────────────────────────────────────────────
-# K线失败日志只有出口、没有调用方,无法定位是哪个调度任务在"源源不断"地报错。
-# 调用方用 `with kline_source("xxx"):` 包裹,失败日志即带上 [src=xxx]。
-# asyncio.to_thread 会传播 contextvars,异步调度里设置也能透到 worker 线程。
-_KLINE_SOURCE: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "kline_source", default=""
-)
-
-
-@contextmanager
-def kline_source(name: str):
-    """标注当前 K线请求的调用来源,写入失败日志便于定位触发方。"""
-    token = _KLINE_SOURCE.set(name or "")
-    try:
-        yield
-    finally:
-        _KLINE_SOURCE.reset(token)
-
-
-def _source_suffix() -> str:
-    src = _KLINE_SOURCE.get()
-    return f" [src={src}]" if src else ""
+# 调用来源标记统一在 market_http(全项目共享一个 contextvar)。
+# 保留 kline_source / _source_suffix 名称,兼容已有调用方(schedulers 等)。
+kline_source = fetch_source
+_source_suffix = source_suffix
 
 
 # ── K线按市场状态缓存 ──────────────────────────────────────────────────────

--- a/src/collectors/kline_collector.py
+++ b/src/collectors/kline_collector.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -13,7 +15,7 @@ import threading
 import time
 
 from src.core.cn_symbol import get_cn_prefix, is_cn_sh
-from src.models.market import MarketCode
+from src.models.market import MARKETS, MarketCode
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,53 @@ _STOOQ_CACHE: dict[str, tuple[float, list["KlineData"]]] = {}
 _STOOQ_CACHE_TTL_SECONDS = 300
 _EASTMONEY_CACHE: dict[str, tuple[float, int, list["KlineData"]]] = {}
 _EASTMONEY_CACHE_TTL_SECONDS = 300
+
+
+# ── 调用来源标记 ───────────────────────────────────────────────────────────
+# K线失败日志只有出口、没有调用方,无法定位是哪个调度任务在"源源不断"地报错。
+# 调用方用 `with kline_source("xxx"):` 包裹,失败日志即带上 [src=xxx]。
+# asyncio.to_thread 会传播 contextvars,异步调度里设置也能透到 worker 线程。
+_KLINE_SOURCE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "kline_source", default=""
+)
+
+
+@contextmanager
+def kline_source(name: str):
+    """标注当前 K线请求的调用来源,写入失败日志便于定位触发方。"""
+    token = _KLINE_SOURCE.set(name or "")
+    try:
+        yield
+    finally:
+        _KLINE_SOURCE.reset(token)
+
+
+def _source_suffix() -> str:
+    src = _KLINE_SOURCE.get()
+    return f" [src={src}]" if src else ""
+
+
+# ── K线按市场状态缓存 ──────────────────────────────────────────────────────
+# 日K一天只定稿一次(收盘后),但调度任务每轮都逐只重新联网拉 → 批量突发触发限流。
+# 交易时段用短 TTL(末根K线盘中会动),收盘后用长 TTL(数据已定稿,无需重复拉)。
+_KLINE_CACHE: dict[str, tuple[float, int, list["KlineData"]]] = {}
+_KLINE_TTL_TRADING_S = 180
+_KLINE_TTL_CLOSED_S = 1800
+
+
+def _kline_cache_ttl(market: MarketCode) -> float:
+    try:
+        md = MARKETS.get(market)
+        if md and md.is_trading_time():
+            return _KLINE_TTL_TRADING_S
+    except Exception:
+        pass
+    return _KLINE_TTL_CLOSED_S
+
+
+def clear_kline_cache() -> None:
+    """清空 K线内存缓存(测试隔离用)。"""
+    _KLINE_CACHE.clear()
 
 
 def _fetch_stooq_us_klines(symbol: str) -> list[KlineData]:
@@ -156,6 +205,7 @@ def _fetch_eastmoney_klines(
     last_err = None
     best: list[KlineData] = []
     for attempt in range(2):
+        _throttle_eastmoney()
         try:
             with httpx.Client(
                 follow_redirects=True,
@@ -200,7 +250,9 @@ def _fetch_eastmoney_klines(
             time.sleep(0.35 * (attempt + 1))
 
     if not best and last_err is not None:
-        logger.warning(f"Eastmoney 获取 {symbol} K线失败: {last_err}")
+        logger.warning(
+            f"Eastmoney 获取 {symbol} K线失败: {last_err}{_source_suffix()}"
+        )
         stale = _EASTMONEY_CACHE.get(cache_key)
         if stale:
             bars = stale[2]
@@ -498,6 +550,56 @@ def _throttle_tencent() -> None:
         _tencent_last_call[0] = time.time()
 
 
+# 东方财富 push2his 在批量突发下会连接级丢弃(Server disconnected) —— 同样做进程级节流。
+_EASTMONEY_MIN_INTERVAL_S = 0.2
+_EASTMONEY_THROTTLE_LOCK = threading.Lock()
+_eastmoney_last_call = [0.0]
+
+
+def _throttle_eastmoney() -> None:
+    """进程级限速:东方财富兜底请求间隔 ≥ _EASTMONEY_MIN_INTERVAL_S,缓解批量突发被连接级拒绝。"""
+    with _EASTMONEY_THROTTLE_LOCK:
+        wait = _EASTMONEY_MIN_INTERVAL_S - (time.time() - _eastmoney_last_call[0])
+        if wait > 0:
+            time.sleep(wait)
+        _eastmoney_last_call[0] = time.time()
+
+
+def _fetch_tencent_klines(
+    symbol: str, market: MarketCode, days: int
+) -> list[KlineData]:
+    """腾讯主路径取日K:进程级节流 + 空响应/异常退避重试(gtimg 批量突发常限流回空 body,重试可自愈)。"""
+    tencent_sym = _tencent_symbol(symbol, market)
+    params = {
+        "param": f"{tencent_sym},day,,,{days},qfq",
+        "_var": "kline_dayqfq",
+    }
+    klines: list[KlineData] = []
+    last_err = None
+    for attempt in range(3):
+        _throttle_tencent()
+        try:
+            with httpx.Client(
+                follow_redirects=True, timeout=10 + attempt * 4, trust_env=False
+            ) as client:  # 行情直连,绕过 env 代理(生产代理会拦行情接口)
+                resp = client.get(TENCENT_KLINE_URL, params=params)
+                text = resp.text
+            klines = _parse_tencent_kline_text(text, tencent_sym)
+            if klines:
+                break
+            last_err = "空响应"  # gtimg 突发限流常回空 body,退避后重试
+        except Exception as e:
+            last_err = e
+        if attempt < 2:
+            time.sleep(0.4 * (attempt + 1) + random.uniform(0, 0.25))
+
+    if not klines and last_err is not None:
+        logger.warning(
+            f"腾讯 K线获取失败(已重试)symbol={symbol}: {last_err}{_source_suffix()}"
+        )
+    return klines
+
+
 def _parse_tencent_kline_text(text: str, tencent_sym: str) -> list[KlineData]:
     """解析腾讯 K 线 JS 变量响应(kline_dayqfq={...})为 KlineData;空/异常返回 []。"""
     if not text or "=" not in text:
@@ -543,42 +645,26 @@ class KlineCollector:
         self.market = market
 
     def get_klines(self, symbol: str, days: int = 60) -> list[KlineData]:
-        """获取日K线数据"""
-        tencent_sym = _tencent_symbol(symbol, self.market)
+        """获取日K线数据(按市场状态缓存,避免调度任务每轮重复联网触发限流)。"""
+        cache_key = f"{self.market.value}:{symbol}"
+        need = max(1, int(days or 1))
+        now = time.time()
+        cached = _KLINE_CACHE.get(cache_key)
+        if (
+            cached
+            and (now - cached[0]) < _kline_cache_ttl(self.market)
+            and cached[1] >= need
+        ):
+            bars = cached[2]
+            return bars[-need:] if len(bars) > need else bars
 
-        params = {
-            "param": f"{tencent_sym},day,,,{days},qfq",
-            "_var": "kline_dayqfq",
-        }
-
-        # 腾讯主路径:进程级节流 + 重试退避(gtimg 在批量/并发突发下常限流回空 body,重试可自愈)
-        klines: list[KlineData] = []
-        last_err = None
-        for attempt in range(3):
-            _throttle_tencent()
-            try:
-                with httpx.Client(
-                    follow_redirects=True, timeout=10 + attempt * 4, trust_env=False
-                ) as client:  # 行情直连,绕过 env 代理(生产代理会拦行情接口)
-                    resp = client.get(TENCENT_KLINE_URL, params=params)
-                    text = resp.text
-                klines = _parse_tencent_kline_text(text, tencent_sym)
-                if klines:
-                    break
-                last_err = "空响应"  # gtimg 突发限流常回空 body,退避后重试
-            except Exception as e:
-                last_err = e
-            if attempt < 2:
-                time.sleep(0.4 * (attempt + 1) + random.uniform(0, 0.25))
-
-        if not klines and last_err is not None:
-            logger.warning(f"腾讯 K线获取失败(已重试)symbol={symbol}: {last_err}")
+        klines = _fetch_tencent_klines(symbol, self.market, days)
 
         # Tencent 对部分美股返回的 day 数据异常偏少（仅 1-2 条），使用 Stooq 回退。
         if self.market == MarketCode.US and len(klines) < max(10, min(days, 30)):
             fallback = _fetch_stooq_us_klines(symbol)
             if fallback:
-                return fallback[-days:]
+                klines = fallback
 
         # CN/HK: Tencent 不足时用 Eastmoney 补全更长历史(仅当确实不足)
         if self.market in (MarketCode.CN, MarketCode.HK):
@@ -587,13 +673,19 @@ class KlineCollector:
                     symbol, self.market, min(max(days, 3000), 20000)
                 )
                 if len(em) > len(klines):
-                    return em[-days:] if len(em) > days else em
+                    klines = em
 
-        return klines
+        # 只缓存非空结果:数据源短暂故障时不把"空"固化,下轮可重试。
+        if klines:
+            _KLINE_CACHE[cache_key] = (now, len(klines), list(klines))
+        return klines[-need:] if len(klines) > need else klines
 
-    def get_technical_indicators(self, symbol: str) -> TechnicalIndicators:
-        """计算技术指标"""
-        klines = self.get_klines(symbol, days=120)
+    def get_technical_indicators(
+        self, symbol: str = "", klines: list[KlineData] | None = None
+    ) -> TechnicalIndicators:
+        """计算技术指标(可传入已取的 klines 复用,避免重复联网)。"""
+        if klines is None:
+            klines = self.get_klines(symbol, days=120)
 
         if not klines:
             return TechnicalIndicators()
@@ -748,11 +840,10 @@ class KlineCollector:
 
     def get_kline_summary(self, symbol: str) -> dict:
         """获取 K 线摘要（用于 prompt 和前端展示）"""
-        klines = self.get_klines(symbol, days=30)
-        indicators = self.get_technical_indicators(symbol)
-
+        klines = self.get_klines(symbol, days=120)
         if not klines:
             return {"error": "无K线数据"}
+        indicators = self.get_technical_indicators(klines=klines)
 
         # 最近5日表现
         recent_5 = klines[-5:] if len(klines) >= 5 else klines

--- a/src/collectors/market_http.py
+++ b/src/collectors/market_http.py
@@ -1,0 +1,162 @@
+"""行情/数据采集的统一 HTTP 工具。
+
+把散落在各 collector 的样板收敛到一处,避免每个文件各写一套且各有缺漏:
+- **直连**:默认 trust_env=False,绕过 env 代理(生产 LAN 代理会拦国内行情/数据接口)。
+- **按 host 节流**:同一域名请求最小间隔,平滑顺序/并发突发(第三方批量突发会限流)。
+- **退避重试**:空响应/异常退避 + 抖动重试。
+- **调用来源标记**:全项目共享一个 contextvar,失败日志带 [src=xxx],定位是哪个任务触发。
+
+来源标记是全局共享的:任何调度入口 `with fetch_source("xxx"):` 包裹后,
+该任务内所有 collector(K线/报价/资金流/...)的失败日志都会带上同一来源。
+asyncio.to_thread 会传播 contextvars,异步调度里设置也能透到 worker 线程。
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import random
+import threading
+import time
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ── 调用来源标记(全局共享)──────────────────────────────────────────────
+_FETCH_SOURCE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "fetch_source", default=""
+)
+
+
+@contextmanager
+def fetch_source(name: str):
+    """标注当前取数的调用来源,写入失败日志便于定位触发方。"""
+    token = _FETCH_SOURCE.set(name or "")
+    try:
+        yield
+    finally:
+        _FETCH_SOURCE.reset(token)
+
+
+def source_suffix() -> str:
+    src = _FETCH_SOURCE.get()
+    return f" [src={src}]" if src else ""
+
+
+# ── 按 host 进程级节流 ───────────────────────────────────────────────────
+_THROTTLE_LOCK = threading.Lock()
+_last_call: dict[str, float] = {}
+
+
+def throttle(host_key: str, min_interval_s: float) -> None:
+    """保证对同一 host 的请求间隔 ≥ min_interval_s,平滑顺序/并发突发。"""
+    if min_interval_s <= 0:
+        return
+    with _THROTTLE_LOCK:
+        wait = min_interval_s - (time.time() - _last_call.get(host_key, 0.0))
+        if wait > 0:
+            time.sleep(wait)
+        _last_call[host_key] = time.time()
+
+
+# ── 统一同步 GET ─────────────────────────────────────────────────────────
+def market_get(
+    url: str,
+    *,
+    host_key: str,
+    params: dict | None = None,
+    headers: dict | None = None,
+    min_interval_s: float = 0.0,
+    timeout: float = 10.0,
+    retries: int = 2,
+    backoff: float = 0.4,
+    jitter: float = 0.25,
+    parse: str = "text",  # "text" | "json" | "content"
+    encoding: str | None = None,  # 强制解码(如 "gbk")
+    symbol: str = "",
+    log_label: str = "",
+    raise_for_status: bool = True,
+    trust_env: bool = False,  # 默认直连,绕过 env 代理
+    follow_redirects: bool = True,
+    verify: bool = True,
+) -> Any | None:
+    """直连 + 按 host 节流 + 退避重试。成功返回解析结果,失败返回 None 并打带来源的日志。"""
+    last_err: Any = None
+    for attempt in range(max(1, retries + 1)):
+        throttle(host_key, min_interval_s)
+        try:
+            with httpx.Client(
+                follow_redirects=follow_redirects,
+                timeout=timeout + attempt * 4,
+                headers=headers,
+                trust_env=trust_env,
+                verify=verify,
+            ) as client:
+                resp = client.get(url, params=params)
+                if raise_for_status:
+                    resp.raise_for_status()
+                if parse == "json":
+                    return resp.json()
+                if parse == "content":
+                    return resp.content
+                if encoding:
+                    return resp.content.decode(encoding, errors="ignore")
+                return resp.text
+        except Exception as e:
+            last_err = e
+        if attempt < retries:
+            time.sleep(backoff * (attempt + 1) + random.uniform(0, jitter))
+
+    if last_err is not None:
+        label = log_label or host_key
+        sym = f" symbol={symbol}" if symbol else ""
+        logger.warning(f"{label} 获取失败{sym}: {last_err}{source_suffix()}")
+    return None
+
+
+# ── 轻量 TTL 缓存 ────────────────────────────────────────────────────────
+# 与 src/core/providers/cache.py 等价,但定义在采集层最底层模块,供各 collector
+# 直接复用——避免 collector 反向 import providers 包触发循环依赖。
+class TTLCache:
+    """单进程内存 TTL 缓存,线程安全,过期 key 在下次 get 时被动剔除。"""
+
+    def __init__(self, default_ttl_sec: float = 20.0, max_size: int = 2048):
+        self._default_ttl = default_ttl_sec
+        self._max_size = max_size
+        self._lock = threading.Lock()
+        self._store: dict[str, tuple[Any, float]] = {}
+
+    def get(self, key: str) -> Any | None:
+        now = time.monotonic()
+        with self._lock:
+            entry = self._store.get(key)
+            if not entry:
+                return None
+            value, expires_at = entry
+            if expires_at <= now:
+                del self._store[key]
+                return None
+            return value
+
+    def set(self, key: str, value: Any, ttl_sec: float | None = None) -> None:
+        ttl = ttl_sec if ttl_sec is not None else self._default_ttl
+        if ttl <= 0:
+            return  # 显式不缓存
+        expires = time.monotonic() + ttl
+        with self._lock:
+            if len(self._store) >= self._max_size and key not in self._store:
+                oldest = min(self._store.items(), key=lambda kv: kv[1][1])
+                del self._store[oldest[0]]
+            self._store[key] = (value, expires)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)

--- a/src/collectors/news_collector.py
+++ b/src/collectors/news_collector.py
@@ -9,6 +9,7 @@ import asyncio
 
 import httpx
 
+from src.collectors.market_http import source_suffix
 from src.core.cn_symbol import get_cn_prefix
 
 logger = logging.getLogger(__name__)
@@ -517,7 +518,7 @@ class EastMoneyNewsCollector(BaseNewsCollector):
             return result
 
         except Exception as e:
-            logger.warning(f"东方财富公告采集失败: {e}")
+            logger.warning(f"东方财富公告采集失败: {e}{source_suffix()}")
             return []
 
     def _parse_item(self, item: dict, symbol: str) -> NewsItem | None:
@@ -651,7 +652,7 @@ class NewsCollector:
                 since = announcement_since if collector.source == "eastmoney" else news_since
                 return await collector.fetch_news(symbols, since)
             except Exception as e:
-                logger.error(f"采集器 {collector.source} 失败: {e}")
+                logger.error(f"采集器 {collector.source} 失败: {e}{source_suffix()}")
                 return []
 
         # 并发采集所有数据源

--- a/src/core/context_scheduler.py
+++ b/src/core/context_scheduler.py
@@ -218,6 +218,7 @@ class ContextMaintenanceScheduler:
             self._evaluate_job,
             "interval",
             hours=self.eval_interval_hours,
+            jitter=120,  # 错峰,避免与 price_alert/paper_trading(60s)同刻写 SQLite
             id="context_maintenance_evaluate",
             replace_existing=True,
             coalesce=True,
@@ -228,6 +229,7 @@ class ContextMaintenanceScheduler:
             "cron",
             hour=4,
             minute=15,
+            jitter=120,
             id="context_maintenance_cleanup",
             replace_existing=True,
             coalesce=True,
@@ -240,6 +242,7 @@ class ContextMaintenanceScheduler:
                 "cron",
                 hour=job_hour,
                 minute=job_minute,
+                jitter=120,  # 错峰,避免与其它调度同刻写 SQLite
                 id=f"context_maintenance_refresh_opportunities_{job_hour:02d}{job_minute:02d}",
                 replace_existing=True,
                 coalesce=True,

--- a/src/core/context_scheduler.py
+++ b/src/core/context_scheduler.py
@@ -8,6 +8,7 @@ import logging
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from src.collectors.kline_collector import kline_source
 from src.core.context_store import cleanup_context_data
 from src.core.entry_candidates import evaluate_entry_candidate_outcomes
 from src.core.prediction_outcome import evaluate_pending_prediction_outcomes
@@ -53,12 +54,13 @@ class ContextMaintenanceScheduler:
                 stats.get("skipped_not_due", 0),
                 stats.get("skipped_no_price", 0),
             )
-            cand_stats = await asyncio.to_thread(
-                evaluate_entry_candidate_outcomes,
-                horizons=(1, 3, 5, 10),
-                snapshot_days=45,
-                limit=500,
-            )
+            with kline_source("outcome_eval"):
+                cand_stats = await asyncio.to_thread(
+                    evaluate_entry_candidate_outcomes,
+                    horizons=(1, 3, 5, 10),
+                    snapshot_days=45,
+                    limit=500,
+                )
             level = logging.INFO if cand_stats.get("evaluated", 0) else logging.DEBUG
             logger.log(
                 level,
@@ -69,12 +71,13 @@ class ContextMaintenanceScheduler:
                 cand_stats.get("skipped_not_due", 0),
                 cand_stats.get("skipped_no_price", 0),
             )
-            strategy_stats = await asyncio.to_thread(
-                evaluate_strategy_outcomes,
-                horizons=(1, 3, 5, 10),
-                snapshot_days=60,
-                limit=1200,
-            )
+            with kline_source("outcome_eval"):
+                strategy_stats = await asyncio.to_thread(
+                    evaluate_strategy_outcomes,
+                    horizons=(1, 3, 5, 10),
+                    snapshot_days=60,
+                    limit=1200,
+                )
             level = logging.INFO if strategy_stats.get("evaluated", 0) else logging.DEBUG
             logger.log(
                 level,
@@ -168,14 +171,15 @@ class ContextMaintenanceScheduler:
             return
         self._refreshing = True
         try:
-            result = await asyncio.to_thread(
-                refresh_strategy_signals,
-                rebuild_candidates=True,
-                max_inputs=500,
-                market_scan_limit=80,
-                max_kline_symbols=60,
-                limit_candidates=2000,
-            )
+            with kline_source("refresh_opportunities"):
+                result = await asyncio.to_thread(
+                    refresh_strategy_signals,
+                    rebuild_candidates=True,
+                    max_inputs=500,
+                    market_scan_limit=80,
+                    max_kline_symbols=60,
+                    limit_candidates=2000,
+                )
             level = logging.INFO if result.get("count", 0) else logging.DEBUG
             logger.log(
                 level,
@@ -190,14 +194,15 @@ class ContextMaintenanceScheduler:
 
     async def refresh_opportunities_once(self) -> dict:
         """手动触发一次机会刷新。"""
-        return await asyncio.to_thread(
-            refresh_strategy_signals,
-            rebuild_candidates=True,
-            max_inputs=500,
-            market_scan_limit=80,
-            max_kline_symbols=60,
-            limit_candidates=2000,
-        )
+        with kline_source("refresh_opportunities"):
+            return await asyncio.to_thread(
+                refresh_strategy_signals,
+                rebuild_candidates=True,
+                max_inputs=500,
+                market_scan_limit=80,
+                max_kline_symbols=60,
+                limit_candidates=2000,
+            )
 
     async def cleanup_once(self) -> dict:
         return await asyncio.to_thread(

--- a/src/core/paper_trading_scheduler.py
+++ b/src/core/paper_trading_scheduler.py
@@ -7,8 +7,18 @@ import logging
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from src.core.paper_trading_engine import ENGINE
+from src.models.market import MARKETS, MarketCode
 
 logger = logging.getLogger(__name__)
+
+
+def _any_market_trading() -> bool:
+    """CN/HK/US 任一在交易时段即为 True。全休市时行情不动,扫描可跳过(行为中性)。"""
+    for m in (MarketCode.CN, MarketCode.HK, MarketCode.US):
+        md = MARKETS.get(m)
+        if md and md.is_trading_time():
+            return True
+    return False
 
 
 class PaperTradingScheduler:
@@ -20,6 +30,9 @@ class PaperTradingScheduler:
     async def _scan_job(self):
         if self._running:
             logger.debug("[模拟盘] 上轮扫描仍在执行，跳过本轮")
+            return
+        if not _any_market_trading():
+            logger.debug("[模拟盘] 全市场休市,跳过本轮扫描")
             return
         self._running = True
         try:

--- a/src/core/price_alert_engine.py
+++ b/src/core/price_alert_engine.py
@@ -170,8 +170,12 @@ class PriceAlertEngine:
         elif ctype == "volume":
             left = _safe_float(quote.get("volume"))
         elif ctype == "volume_ratio":
-            summary = await self._get_kline_summary_cached(market, symbol)
-            left = _safe_float(summary.get("volume_ratio"))
+            # 优先用报价里的量比(腾讯 parts[49]),免拉 K线;
+            # 仅当报价缺量比(如美股 yfinance)才回退 K线摘要。
+            left = _safe_float(quote.get("volume_ratio"))
+            if left is None:
+                summary = await self._get_kline_summary_cached(market, symbol)
+                left = _safe_float(summary.get("volume_ratio"))
         else:
             return False, {"type": ctype, "error": "unsupported_type"}
 

--- a/src/core/price_alert_engine.py
+++ b/src/core/price_alert_engine.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from src.collectors.kline_collector import KlineCollector
+from src.collectors.kline_collector import KlineCollector, kline_source
 from src.core.notifier import NotifierManager
 from src.core.providers import ProviderRequest, get_quote_orchestrator
 from src.models.market import MarketCode, MARKETS
@@ -142,7 +142,8 @@ class PriceAlertEngine:
         if cached and now - cached[0] < self.kline_ttl_sec:
             return cached[1]
         try:
-            summary = await asyncio.to_thread(KlineCollector(market).get_kline_summary, symbol)
+            with kline_source("price_alert"):
+                summary = await asyncio.to_thread(KlineCollector(market).get_kline_summary, symbol)
         except Exception:
             summary = {}
         self._kline_cache[key] = (now, summary or {})

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -5,6 +5,7 @@ from typing import Callable, Awaitable
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from src.agents.base import BaseAgent, AgentContext
+from src.collectors.kline_collector import kline_source
 from src.core.agent_runs import record_agent_run
 from src.core.log_context import log_context
 from src.models.market import MARKETS
@@ -98,7 +99,8 @@ class AgentScheduler:
                             )
                             continue
                         try:
-                            res = await agent.run_single(context, stock.symbol)  # type: ignore[attr-defined]
+                            with kline_source(f"agent:{agent_name}"):
+                                res = await agent.run_single(context, stock.symbol)  # type: ignore[attr-defined]
                             processed += 1
                             try:
                                 notify_error = (
@@ -131,7 +133,8 @@ class AgentScheduler:
                         model_label=context.model_label,
                     )
                 else:
-                    result = await agent.run(context)
+                    with kline_source(f"agent:{agent_name}"):
+                        result = await agent.run(context)
                     duration_ms = int((time.monotonic() - start) * 1000)
                     notify_error = ""
                     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,13 +56,24 @@ def _mock_stock_link_platform(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _clear_kline_cache():
-    """清空 K线内存缓存,避免用例间互相污染(get_klines 现按市场状态缓存)。"""
-    from src.collectors import kline_collector
+def _clear_market_caches():
+    """清空采集层内存缓存,避免用例间互相污染(K线/报价/资金流等现按 TTL 缓存)。"""
+    from src.collectors import (
+        akshare_collector,
+        capital_flow_collector,
+        discovery_collector,
+        kline_collector,
+    )
 
-    kline_collector.clear_kline_cache()
+    def _clear():
+        kline_collector.clear_kline_cache()
+        akshare_collector._QUOTE_CACHE.clear()
+        capital_flow_collector._FLOW_CACHE.clear()
+        discovery_collector._DISCOVERY_CACHE.clear()
+
+    _clear()
     yield
-    kline_collector.clear_kline_cache()
+    _clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,16 @@ def _mock_stock_link_platform(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _clear_kline_cache():
+    """清空 K线内存缓存,避免用例间互相污染(get_klines 现按市场状态缓存)。"""
+    from src.collectors import kline_collector
+
+    kline_collector.clear_kline_cache()
+    yield
+    kline_collector.clear_kline_cache()
+
+
 # ---------------------------------------------------------------------------
 # 共用工厂 fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_collectors_hardening.py
+++ b/tests/test_collectors_hardening.py
@@ -1,0 +1,112 @@
+"""采集层批量整治 P1:共享 market_http(节流/重试/来源)+ 各 collector 缓存。
+
+价格提醒所需的量比直接从腾讯报价 parts[49] 取,免再拉 K线;
+报价/资金流/异动加 TTL 缓存,避免调度任务每轮重复联网触发限流。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.collectors import akshare_collector, capital_flow_collector, market_http
+from src.models.market import MarketCode
+
+
+def _make_quote_line(volume_ratio: str = "1.25") -> str:
+    """造一条腾讯报价行(≥50 字段),index 49 为量比。"""
+    f = ["0"] * 60
+    f[1] = "贵州茅台"
+    f[2] = "600519"
+    f[3] = "1700.0"  # 现价
+    f[4] = "1690.0"  # 昨收
+    f[5] = "1695.0"  # 开盘
+    f[6] = "12345"  # 成交量
+    f[31] = "10.0"  # 涨跌额
+    f[32] = "0.59"  # 涨跌幅
+    f[33] = "1710.0"  # 最高
+    f[34] = "1680.0"  # 最低
+    f[35] = "1700.0/12345/2000000"  # 价/量/额
+    f[38] = "0.5"  # 换手率
+    f[39] = "30.0"  # 市盈率
+    f[44] = "1.0e12"
+    f[45] = "2.0e12"
+    f[49] = volume_ratio  # 量比
+    return 'v_sh600519="' + "~".join(f) + '";'
+
+
+def test_tencent_quote_parses_volume_ratio():
+    """腾讯报价应解析出量比(parts[49]),供价格提醒直接用、免拉 K线。"""
+    parsed = akshare_collector._parse_tencent_line(_make_quote_line("1.25"))
+    assert parsed is not None
+    assert parsed["volume_ratio"] == 1.25
+
+
+def test_tencent_quotes_cached(monkeypatch):
+    """同一批 symbols 的报价在 TTL 内应命中缓存,不重复联网。"""
+    calls = {"n": 0}
+    line = _make_quote_line("1.1")
+
+    def fake_market_get(url, **kwargs):
+        calls["n"] += 1
+        return line.encode("gbk")
+
+    monkeypatch.setattr(akshare_collector, "market_get", fake_market_get)
+    akshare_collector._fetch_tencent_quotes(["sh600519"])
+    akshare_collector._fetch_tencent_quotes(["sh600519"])
+    assert calls["n"] == 1, f"第二次应命中报价缓存,实际联网 {calls['n']} 次"
+
+
+def test_capital_flow_cached(monkeypatch):
+    """资金流为日级数据,同一只在 TTL 内应命中缓存,不重复联网。"""
+    calls = {"n": 0}
+    fake = {
+        "data": {
+            "code": "600519",
+            "name": "贵州茅台",
+            "klines": ["2026-06-18,100,1,2,3,4,5,6,7,8,9,10,11,12,13,14"],
+        }
+    }
+
+    def fake_market_get(url, **kwargs):
+        calls["n"] += 1
+        return fake
+
+    monkeypatch.setattr(capital_flow_collector, "market_get", fake_market_get)
+    c = capital_flow_collector.CapitalFlowCollector(MarketCode.CN)
+    assert c.get_capital_flow("600519") is not None
+    assert c.get_capital_flow("600519") is not None
+    assert calls["n"] == 1, f"第二次应命中资金流缓存,实际联网 {calls['n']} 次"
+
+
+def test_market_get_retries_and_logs_source(monkeypatch, caplog):
+    """market_get 失败应退避重试,并在日志带上 [src=...] 调用来源。"""
+    calls = {"n": 0}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, *args, **kwargs):
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(market_http.httpx, "Client", _FakeClient)
+    monkeypatch.setattr(market_http.time, "sleep", lambda *_: None)
+
+    with caplog.at_level(logging.WARNING):
+        with market_http.fetch_source("unit_src"):
+            out = market_http.market_get(
+                "http://x", host_key="x", retries=2, log_label="测试"
+            )
+
+    assert out is None
+    assert calls["n"] == 3, f"应 1 次 + 重试 2 次 = 3 次,实际 {calls['n']}"
+    assert any(
+        "[src=unit_src]" in r.getMessage() for r in caplog.records
+    ), caplog.text

--- a/tests/test_kline_collector_cache.py
+++ b/tests/test_kline_collector_cache.py
@@ -1,0 +1,138 @@
+"""K线采集的缓存 / 单次取数 / 失败来源日志(批量整治 P0)。
+
+日K一天只定稿一次,但调度任务每轮都逐只重新联网拉 → 批量突发触发第三方限流。
+按市场状态缓存 + 摘要单次取数 + 失败日志带调用来源,是止血的核心三件套。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.collectors import kline_collector
+from src.models.market import MarketCode
+
+
+def _mk_bars(n: int) -> list[kline_collector.KlineData]:
+    """造 n 根有波动的日K,够算各项指标。"""
+    out = []
+    for i in range(n):
+        close = 10.0 + (i % 7)
+        out.append(
+            kline_collector.KlineData(
+                date=f"2026-{(i % 12) + 1:02d}-{(i % 28) + 1:02d}",
+                open=close,
+                close=close,
+                high=close + 1,
+                low=close - 1,
+                volume=100.0 + i,
+            )
+        )
+    return out
+
+
+def test_get_klines_caches_within_ttl(monkeypatch):
+    """同一只 K线在 TTL 内应命中内存缓存,不重复联网(避免批量突发触发限流)。"""
+    calls = {"n": 0}
+    bars = _mk_bars(130)
+
+    def fake_fetch(symbol, market, days):
+        calls["n"] += 1
+        return list(bars)
+
+    monkeypatch.setattr(kline_collector, "_fetch_tencent_klines", fake_fetch)
+    monkeypatch.setattr(kline_collector, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    c = kline_collector.KlineCollector(MarketCode.CN)
+    c.get_klines("600519", days=120)
+    c.get_klines("600519", days=120)
+
+    assert calls["n"] == 1, f"第二次应命中缓存,实际联网 {calls['n']} 次"
+
+
+def test_cache_serves_shorter_request_from_longer_entry(monkeypatch):
+    """缓存里已有较长序列时,更短的请求应直接切片返回,不再联网。"""
+    calls = {"n": 0}
+    bars = _mk_bars(130)
+
+    def fake_fetch(symbol, market, days):
+        calls["n"] += 1
+        return list(bars)
+
+    monkeypatch.setattr(kline_collector, "_fetch_tencent_klines", fake_fetch)
+    monkeypatch.setattr(kline_collector, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    c = kline_collector.KlineCollector(MarketCode.CN)
+    c.get_klines("600519", days=120)          # 取并缓存 130 根
+    out = c.get_klines("600519", days=30)     # 应从缓存切 30 根
+
+    assert calls["n"] == 1, f"更短请求应命中缓存,实际联网 {calls['n']} 次"
+    assert len(out) == 30
+
+
+def test_empty_result_not_cached(monkeypatch):
+    """取数为空时不应写缓存,下一轮仍会重试(别把瞬时故障固化为空)。"""
+    calls = {"n": 0}
+
+    def fake_fetch(symbol, market, days):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(kline_collector, "_fetch_tencent_klines", fake_fetch)
+    monkeypatch.setattr(kline_collector, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    c = kline_collector.KlineCollector(MarketCode.CN)
+    assert c.get_klines("600519", days=120) == []
+    assert c.get_klines("600519", days=120) == []
+    assert calls["n"] == 2, "空结果不应缓存,两次都应联网重试"
+
+
+def test_get_kline_summary_fetches_klines_once(monkeypatch):
+    """K线摘要应只取一次 K线(原来 30天 + 120天双取),指标复用同一份。"""
+    calls = {"n": 0}
+    bars = _mk_bars(130)
+
+    def fake_get_klines(self, symbol, days=60):
+        calls["n"] += 1
+        return list(bars)
+
+    monkeypatch.setattr(
+        kline_collector.KlineCollector, "get_klines", fake_get_klines
+    )
+
+    summary = kline_collector.KlineCollector(MarketCode.CN).get_kline_summary("600519")
+
+    assert calls["n"] == 1, f"摘要应只取一次 K线,实际 {calls['n']} 次"
+    assert summary.get("ma5") is not None, "指标应基于复用的 K线算出"
+
+
+def test_failure_log_includes_caller_source(monkeypatch, caplog):
+    """失败日志应带上调用来源 [src=...],便于定位是哪个调度任务在刷屏。"""
+    monkeypatch.setattr(kline_collector, "_throttle_tencent", lambda: None)
+    monkeypatch.setattr(kline_collector.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(kline_collector, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    class _Resp:
+        text = "kline_dayqfq="  # 空 body → 解析为空 → 触发失败日志
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, *args, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(kline_collector.httpx, "Client", _FakeClient)
+
+    with caplog.at_level(logging.WARNING):
+        with kline_collector.kline_source("unit_test_src"):
+            kline_collector.KlineCollector(MarketCode.CN).get_klines("000001", days=60)
+
+    assert any(
+        "[src=unit_test_src]" in r.getMessage() for r in caplog.records
+    ), f"失败日志应含来源标记,实际: {caplog.text}"

--- a/tests/test_price_alert_volume_ratio.py
+++ b/tests/test_price_alert_volume_ratio.py
@@ -1,0 +1,63 @@
+"""价格提醒的量比条件应优先用报价字段,不再无谓地拉 K线(批量整治 P2)。
+
+CN/HK 报价已带量比(腾讯 parts[49]);仅当报价缺量比(如美股)才回退 K线摘要。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.core.price_alert_engine import PriceAlertEngine
+from src.models.market import MarketCode
+
+
+def test_volume_ratio_uses_quote_not_kline(monkeypatch):
+    """报价带量比时,量比条件直接用报价,不应再拉 K线。"""
+    eng = PriceAlertEngine()
+    called = {"kline": 0}
+
+    async def fake_kline(market, symbol):
+        called["kline"] += 1
+        return {"volume_ratio": 9.9}
+
+    monkeypatch.setattr(eng, "_get_kline_summary_cached", fake_kline)
+
+    quote = {"current_price": 10.0, "volume_ratio": 2.5}
+    ok, detail = asyncio.run(
+        eng._eval_condition(
+            {"type": "volume_ratio", "op": ">", "value": 2.0},
+            quote,
+            MarketCode.CN,
+            "600519",
+        )
+    )
+
+    assert ok is True
+    assert detail["actual"] == 2.5
+    assert called["kline"] == 0, "有报价量比时不应再拉 K线"
+
+
+def test_volume_ratio_falls_back_to_kline_when_quote_missing(monkeypatch):
+    """报价无量比(如美股)时,量比条件回退到 K线摘要。"""
+    eng = PriceAlertEngine()
+    called = {"kline": 0}
+
+    async def fake_kline(market, symbol):
+        called["kline"] += 1
+        return {"volume_ratio": 3.0}
+
+    monkeypatch.setattr(eng, "_get_kline_summary_cached", fake_kline)
+
+    quote = {"current_price": 200.0}  # 无 volume_ratio 字段
+    ok, detail = asyncio.run(
+        eng._eval_condition(
+            {"type": "volume_ratio", "op": ">", "value": 2.0},
+            quote,
+            MarketCode.US,
+            "AAPL",
+        )
+    )
+
+    assert ok is True
+    assert detail["actual"] == 3.0
+    assert called["kline"] == 1, "报价缺量比时应回退 K线一次"


### PR DESCRIPTION
## 背景

生产 K线"源源不断"报错(腾讯空响应 / 东财 `Server disconnected without sending a response`)。排查结论:**不是网络断**(生产详情页单只取数正常即为证),而是一类自伤式故障——后台调度任务过度/重复联网拉日K → 批量突发触发第三方限流,外加一个仍在泄漏的代理 bug。

全量审计 collectors / providers / 调度器后,分阶段整治。完整方案见 `.docs/market-data-fetch-remediation-plan.md`(本地)。

## 改动(4 阶段)

**P0 止血** `ddf7a01`
- `discovery_collector` trust_env=True→False(全项目最后一个代理泄漏,生产代理会拦东财)
- K线:`get_klines` 按市场状态缓存(交易180s/收盘1800s,只缓存非空)+ 切片复用;`get_kline_summary` 单次取数(原 30天+120天双取);东财兜底节流;失败日志带 `[src=]`
- 调度入口来源标记:`refresh_opportunities` / `outcome_eval` / `price_alert` / `agent:<name>`

**P1 采集层加固** `c53b04f`
- 新增 `src/collectors/market_http.py`:统一直连 + 按 host 进程级节流 + 退避重试 + 调用来源标记 + 内置 TTLCache
- 报价(+量比 `parts[49]`)/ 资金流(600s)/ 异动(90s)加缓存;events/news 失败日志带来源
- 关键:Provider 大多只包一层 collector → 在 collector 层加固即同时治好 orchestrator 与直连两条路径

**P2 调度减负** `e1a918a`
- 价格提醒量比改用报价字段,CN/HK 不再拉 K线(美股回退)
- 模拟盘 60s 扫描全市场休市时跳过(行情不动,行为中性)
- context cron 加 `jitter=120` 错峰(缓解 SQLite `database is locked`)

**P3 收口** `4bb3938`
- 生产默认关闭 uvicorn reload(仅 `DEV_RELOAD=1` 开启)
- SQLite WAL/busy_timeout 已在 `database.py` 存在,无需新增
- 直连收口走 orchestrator / orchestrator semaphore / K线批量取数:收益已被 P0/P1 覆盖,评估后不做

## 效果

- 机会刷新一轮的 K线请求:~120 次 → 单取 ~60 → 缓存命中后趋近 0
- 价格提醒 CN/HK 完全不碰 K线
- 任何残留报错带 `[src=]`,一眼定位触发方

## 测试

`python -m pytest tests/` → **284 passed, 1 skipped**(pre-push hook 已跑通)。新增 11 用例:K线缓存/切片/空不缓存/单取/来源日志、量比解析、报价/资金流缓存、market_get 重试+来源、价格提醒量比走报价/回退。

## 核实结论(非 bug,未改)

- 模拟盘 entries/exits 双取报价:已被 P1 报价缓存(5s)覆盖
- `intraday_monitor` single 模式:`run_single` 已按传入 symbol 过滤,审计误报