### PR TITLE
feat: 加仓成本测算 + AI 快速评估(含基本面/消息面)

### DIFF
--- a/frontend/packages/api/src/insight.ts
+++ b/frontend/packages/api/src/insight.ts
@@ -52,4 +52,34 @@ export const insightApi = {
         include_quotes: params?.include_quotes,
       })
     ),
+
+  addPositionEval: (params: AddPositionEvalParams) =>
+    fetchAPI<AddPositionEvalResult>('/insights/add-position-eval', {
+      method: 'POST',
+      body: JSON.stringify(params),
+      timeoutMs: 60000, // AI 评估较慢,放宽超时
+    }),
+}
+
+export interface AddPositionEvalParams {
+  symbol: string
+  market: string
+  current_quantity: number
+  current_cost: number
+  add_quantity: number
+  add_price: number
+  model_id?: number
+}
+
+export interface AddPositionEvalResult {
+  symbol: string
+  market: string
+  action: string // 加仓 / 建仓
+  new_cost: number
+  dilute_abs: number
+  dilute_pct: number
+  total_quantity: number
+  total_invested: number
+  verdict: string // 适合 / 谨慎 / 不适合 / 未知
+  content: string // markdown 结论
 }

--- a/frontend/packages/biz-ui/src/components/add-position-calculator.tsx
+++ b/frontend/packages/biz-ui/src/components/add-position-calculator.tsx
@@ -1,0 +1,291 @@
+import { useMemo, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { insightApi, type AddPositionEvalResult } from '@panwatch/api'
+import { Button } from '@panwatch/base-ui/components/ui/button'
+import { Input } from '@panwatch/base-ui/components/ui/input'
+import { useToast } from '@panwatch/base-ui/components/ui/toast'
+
+export interface AddPositionCalc {
+  newQty: number
+  newCost: number
+  diluteAbs: number
+  dilutePct: number
+  totalInvested: number
+  isAdd: boolean
+}
+
+/** 加仓后摊薄成本(正算)。无效输入返回 null。 */
+export function calcAddPosition(
+  curQty: number,
+  curCost: number,
+  addQty: number,
+  addPrice: number,
+): AddPositionCalc | null {
+  if (!(addQty > 0) || !(addPrice > 0)) return null
+  const newQty = curQty + addQty
+  if (!(newQty > 0)) return null
+  const newCost = (curQty * curCost + addQty * addPrice) / newQty
+  const isAdd = curQty > 0 && curCost > 0
+  const diluteAbs = isAdd ? curCost - newCost : 0
+  const dilutePct = isAdd && curCost > 0 ? (diluteAbs / curCost) * 100 : 0
+  return { newQty, newCost, diluteAbs, dilutePct, totalInvested: newQty * newCost, isAdd }
+}
+
+/** 反推:把成本降到 target 需要按 addPrice 加多少股。仅当 addPrice < target < curCost 可行。 */
+export function calcSharesForTargetCost(
+  curQty: number,
+  curCost: number,
+  addPrice: number,
+  target: number,
+): number | null {
+  if (!(curQty > 0) || !(curCost > 0)) return null
+  if (!(addPrice > 0) || !(target > 0)) return null
+  if (!(addPrice < target && target < curCost)) return null
+  const q = (curQty * (curCost - target)) / (target - addPrice)
+  return q > 0 ? q : null
+}
+
+function fmt(n: number | null | undefined, d = 2): string {
+  if (n == null || !isFinite(n)) return '--'
+  return n.toFixed(d)
+}
+function fmtInt(n: number | null | undefined): string {
+  if (n == null || !isFinite(n)) return '--'
+  return Math.round(n).toLocaleString()
+}
+
+const VERDICT_STYLE: Record<string, string> = {
+  适合: 'bg-emerald-500/15 text-emerald-500 border-emerald-500/30',
+  谨慎: 'bg-amber-500/15 text-amber-600 border-amber-500/30',
+  不适合: 'bg-rose-500/15 text-rose-500 border-rose-500/30',
+  未知: 'bg-muted text-muted-foreground border-border',
+}
+
+interface Props {
+  symbol: string
+  market: string
+  currentQuantity: number
+  currentCost: number
+  currentPrice?: number | null
+}
+
+export default function AddPositionCalculator({
+  symbol,
+  market,
+  currentQuantity,
+  currentCost,
+  currentPrice,
+}: Props) {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [mode, setMode] = useState<'shares' | 'amount'>('shares')
+  const [addRaw, setAddRaw] = useState('')
+  const [priceRaw, setPriceRaw] = useState('')
+  const [targetRaw, setTargetRaw] = useState('')
+  const [aiLoading, setAiLoading] = useState(false)
+  const [aiResult, setAiResult] = useState<AddPositionEvalResult | null>(null)
+
+  const isCN = market === 'CN'
+
+  const addPrice = useMemo(() => {
+    const p = parseFloat(priceRaw)
+    if (isFinite(p) && p > 0) return p
+    return currentPrice && currentPrice > 0 ? currentPrice : 0
+  }, [priceRaw, currentPrice])
+
+  // 输入(股数/金额)→ 加仓股数
+  const addQty = useMemo(() => {
+    const v = parseFloat(addRaw)
+    if (!isFinite(v) || v <= 0) return 0
+    if (mode === 'shares') return v
+    return addPrice > 0 ? v / addPrice : 0
+  }, [addRaw, mode, addPrice])
+
+  const calc = useMemo(
+    () => calcAddPosition(currentQuantity, currentCost, addQty, addPrice),
+    [currentQuantity, currentCost, addQty, addPrice],
+  )
+
+  const reverseShares = useMemo(() => {
+    const t = parseFloat(targetRaw)
+    if (!isFinite(t) || t <= 0) return null
+    return calcSharesForTargetCost(currentQuantity, currentCost, addPrice, t)
+  }, [targetRaw, currentQuantity, currentCost, addPrice])
+
+  const runAi = async () => {
+    if (!calc || addQty <= 0 || addPrice <= 0) {
+      toast('请先填写有效的加仓股数/金额与价格', 'error')
+      return
+    }
+    setAiLoading(true)
+    setAiResult(null)
+    try {
+      const res = await insightApi.addPositionEval({
+        symbol,
+        market,
+        current_quantity: currentQuantity,
+        current_cost: currentCost,
+        add_quantity: Math.round(addQty),
+        add_price: addPrice,
+      })
+      setAiResult(res)
+    } catch (e: any) {
+      toast(e?.message || 'AI 评估失败', 'error')
+    } finally {
+      setAiLoading(false)
+    }
+  }
+
+  const pricePlaceholder = currentPrice && currentPrice > 0 ? String(currentPrice) : '加仓价'
+  const hasHolding = currentQuantity > 0 && currentCost > 0
+  const lotWarn = isCN && addQty > 0 && Math.round(addQty) % 100 !== 0
+
+  return (
+    <div className="mt-3 border-t border-border/50 pt-3">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between text-[11px] text-muted-foreground"
+      >
+        <span>加仓测算{hasHolding ? '' : '（当前空仓 · 建仓测算）'}</span>
+        <span>{open ? '收起 ▾' : '展开 ▸'}</span>
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2 text-[12px]">
+          <div className="flex gap-1">
+            {(['shares', 'amount'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`rounded border px-2 py-0.5 text-[11px] ${
+                  mode === m
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border text-muted-foreground'
+                }`}
+              >
+                {m === 'shares' ? '按股数' : '按金额'}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <label className="space-y-1">
+              <div className="text-[10px] text-muted-foreground">
+                {mode === 'shares' ? '加仓股数' : '加仓金额(元)'}
+              </div>
+              <Input
+                value={addRaw}
+                onChange={(e) => setAddRaw(e.target.value)}
+                inputMode="decimal"
+                placeholder={mode === 'shares' ? '如 200' : '如 10000'}
+              />
+            </label>
+            <label className="space-y-1">
+              <div className="text-[10px] text-muted-foreground">加仓价</div>
+              <Input
+                value={priceRaw}
+                onChange={(e) => setPriceRaw(e.target.value)}
+                inputMode="decimal"
+                placeholder={pricePlaceholder}
+              />
+            </label>
+          </div>
+
+          {mode === 'amount' && addQty > 0 && (
+            <div className="text-[10px] text-muted-foreground">
+              ≈ {fmtInt(addQty)} 股{isCN ? `（≈${fmtInt(addQty / 100)} 手）` : ''}
+            </div>
+          )}
+
+          {calc ? (
+            <div className="space-y-1 rounded bg-accent/15 p-2">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{calc.isAdd ? '加仓后成本' : '建仓成本'}</span>
+                <span className="font-mono">{fmt(calc.newCost)}</span>
+              </div>
+              {calc.isAdd && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">摊薄</span>
+                  <span className={`font-mono ${calc.diluteAbs >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+                    {calc.diluteAbs >= 0 ? '↓' : '↑'}
+                    {fmt(Math.abs(calc.diluteAbs))}（{fmt(Math.abs(calc.dilutePct))}%）
+                  </span>
+                </div>
+              )}
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">合计股数 / 投入</span>
+                <span className="font-mono">
+                  {fmtInt(calc.newQty)} / {fmtInt(calc.totalInvested)}
+                </span>
+              </div>
+              {lotWarn && (
+                <div className="text-[10px] text-amber-600">提示:A股通常 100 股/手,建议取整到 100 的倍数</div>
+              )}
+            </div>
+          ) : (
+            <div className="text-[11px] text-muted-foreground">填写加仓股数/金额与价格后自动计算</div>
+          )}
+
+          {hasHolding && (
+            <div className="grid grid-cols-2 items-end gap-2">
+              <label className="space-y-1">
+                <div className="text-[10px] text-muted-foreground">反推:目标成本</div>
+                <Input
+                  value={targetRaw}
+                  onChange={(e) => setTargetRaw(e.target.value)}
+                  inputMode="decimal"
+                  placeholder={`< ${fmt(currentCost)}`}
+                />
+              </label>
+              <div className="pb-1 text-[11px]">
+                {targetRaw.trim() === '' ? (
+                  <span className="text-muted-foreground">按加仓价反推所需股数</span>
+                ) : reverseShares != null ? (
+                  <span>
+                    需加 <span className="font-mono text-foreground">{fmtInt(reverseShares)}</span> 股
+                    {isCN ? `（≈${fmtInt(Math.ceil(reverseShares / 100))} 手）` : ''}
+                    <br />约 <span className="font-mono">{fmtInt(reverseShares * addPrice)}</span> 元
+                  </span>
+                ) : (
+                  <span className="text-amber-600">需 加仓价 &lt; 目标 &lt; 现成本 才能降到该成本</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="pt-1">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="w-full"
+              disabled={aiLoading || !calc}
+              onClick={runAi}
+            >
+              {aiLoading ? 'AI 评估中…' : '让 AI 评估适不适合加仓'}
+            </Button>
+          </div>
+
+          {aiResult && (
+            <div className="space-y-1 rounded border border-border/60 p-2">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`rounded border px-2 py-0.5 text-[11px] ${
+                    VERDICT_STYLE[aiResult.verdict] || VERDICT_STYLE['未知']
+                  }`}
+                >
+                  {aiResult.verdict}
+                </span>
+                <span className="text-[10px] text-muted-foreground">AI 结论 · 仅供参考</span>
+              </div>
+              <div className="prose prose-sm dark:prose-invert max-w-none break-words text-[12px] leading-relaxed [&_p]:my-1 [&_ul]:my-1">
+                <ReactMarkdown>{aiResult.content}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/biz-ui/src/components/stock-insight-modal.tsx
+++ b/frontend/packages/biz-ui/src/components/stock-insight-modal.tsx
@@ -21,6 +21,7 @@ import { KlineIndicators } from '@panwatch/biz-ui/components/kline-indicators'
 import { buildKlineSuggestion } from '@/lib/kline-scorer'
 import StockPriceAlertPanel from '@panwatch/biz-ui/components/stock-price-alert-panel'
 import { TechnicalBadge } from '@panwatch/biz-ui/components/technical-badge'
+import AddPositionCalculator from '@panwatch/biz-ui/components/add-position-calculator'
 
 interface QuoteResponse {
   symbol: string
@@ -1480,6 +1481,13 @@ export default function StockInsightModal(props: {
                       ) : (
                         <div className="text-[11px] text-muted-foreground">未在持仓中</div>
                       )}
+                      <AddPositionCalculator
+                        symbol={symbol}
+                        market={market}
+                        currentQuantity={holdingAgg?.quantity ?? 0}
+                        currentCost={holdingAgg?.unitCost ?? 0}
+                        currentPrice={quote?.current_price ?? null}
+                      />
                     </div>
                   </div>
 

--- a/src/web/api/insights.py
+++ b/src/web/api/insights.py
@@ -1,13 +1,26 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from typing import List
+
+from sqlalchemy.orm import Session
 
 from src.models.market import MarketCode
 from src.collectors.akshare_collector import _tencent_symbol, _fetch_tencent_quotes
 from src.collectors.kline_collector import KlineCollector
 from src.core.suggestion_pool import get_latest_suggestions
+from src.web.api.chat import (
+    _build_stock_context,
+    _fetch_realtime_context,
+    _fetch_technical_context,
+    _get_ai_client,
+)
+from src.web.database import get_db
+from src.web.models import Stock
+import asyncio
+import logging
 import time
 
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -102,3 +115,154 @@ def insights_batch(payload: InsightsBatchRequest):
         })
 
     return results
+
+
+class AddPositionEvalRequest(BaseModel):
+    symbol: str
+    market: str = "CN"
+    current_quantity: float = Field(0, ge=0, description="当前持仓股数(0=建仓)")
+    current_cost: float = Field(0, ge=0, description="当前成本(单价)")
+    add_quantity: float = Field(..., gt=0, description="加仓股数")
+    add_price: float = Field(..., gt=0, description="加仓价格")
+    model_id: int | None = None
+
+
+_VERDICTS = ("不适合", "谨慎", "适合")  # 先长后短:'不适合' 含 '适合',顺序不能反
+
+
+def _parse_verdict(text: str) -> str:
+    """从 AI 回复粗解析结论标签;命中不到返回'未知'。"""
+    head = (text or "")[:120]
+    for v in _VERDICTS:
+        if v in head:
+            return v
+    return "未知"
+
+
+async def _fetch_fundamental_context(symbol: str, market: str) -> str:
+    """基本面摘要:PE / 换手率 / 市值 / 今日振幅(取自实时行情,失败返回空)。"""
+    try:
+        mc = MarketCode(market) if market in ("CN", "HK", "US") else MarketCode.CN
+        rows = await asyncio.to_thread(
+            _fetch_tencent_quotes, [_tencent_symbol(symbol, mc)]
+        )
+        if not rows:
+            return ""
+        q = rows[0]
+        parts: list[str] = []
+        if q.get("pe_ratio") not in (None, 0):
+            parts.append(f"市盈率 {q['pe_ratio']}")
+        if q.get("turnover_rate") not in (None, 0):
+            parts.append(f"换手率 {q['turnover_rate']}%")
+        if q.get("circulating_market_value"):
+            parts.append(f"流通市值 {q['circulating_market_value']}亿")
+        if q.get("total_market_value"):
+            parts.append(f"总市值 {q['total_market_value']}亿")
+        hi, lo, pc = q.get("high_price"), q.get("low_price"), q.get("prev_close")
+        if hi and lo and pc:
+            parts.append(f"今日振幅 {(hi - lo) / pc * 100:.2f}%")
+        return ("基本面:" + "，".join(parts)) if parts else ""
+    except Exception as e:
+        logger.debug(f"基本面获取失败 {symbol}: {e}")
+        return ""
+
+
+async def _fetch_message_context(db: Session, symbol: str, market: str) -> str:
+    """消息面摘要:近 3 天新闻/公告标题 + 本地最近 AI 建议/分析(失败降级为空)。"""
+    parts: list[str] = []
+    try:
+        from src.collectors.news_collector import NewsCollector
+
+        stock = db.query(Stock).filter(Stock.symbol == symbol).first()
+        name = stock.name if stock else symbol
+        collector = NewsCollector.from_database()
+        items = await collector.fetch_all(
+            symbols=[symbol], since_hours=72, symbol_names={symbol: name}
+        )
+        items = sorted(items, key=lambda x: x.publish_time, reverse=True)[:5]
+        if items:
+            lines = [
+                f"- {it.title}（{it.publish_time.strftime('%m-%d')}）" for it in items
+            ]
+            parts.append("近期新闻/公告:\n" + "\n".join(lines))
+    except Exception as e:
+        logger.debug(f"消息面新闻获取失败 {symbol}: {e}")
+
+    try:
+        ctx = _build_stock_context(db, symbol, market)
+        if ctx:
+            parts.append(ctx)
+    except Exception:
+        pass
+
+    return "\n\n".join(parts)
+
+
+@router.post("/add-position-eval")
+async def add_position_eval(req: AddPositionEvalRequest, db: Session = Depends(get_db)):
+    """加仓快速评估:按服务端口径算摊薄成本 + 让 AI 给 适合/谨慎/不适合 结论。"""
+    market = _parse_market(req.market).value
+    cur_q = max(0.0, float(req.current_quantity or 0))
+    cur_c = max(0.0, float(req.current_cost or 0))
+    add_q = float(req.add_quantity)
+    add_p = float(req.add_price)
+    if add_q <= 0 or add_p <= 0:
+        raise HTTPException(400, "加仓股数与价格必须大于 0")
+
+    new_q = cur_q + add_q
+    new_cost = (cur_q * cur_c + add_q * add_p) / new_q if new_q > 0 else add_p
+    is_add = cur_q > 0 and cur_c > 0
+    dilute_abs = (cur_c - new_cost) if is_add else 0.0
+    dilute_pct = (dilute_abs / cur_c * 100) if is_add and cur_c > 0 else 0.0
+    action = "加仓" if is_add else "建仓"
+
+    # 上下文:实时行情 + 基本面 + 技术面 + 消息面(新闻/公告/本地观点)
+    realtime = await _fetch_realtime_context(req.symbol, market)
+    fundamental = await _fetch_fundamental_context(req.symbol, market)
+    technical = await _fetch_technical_context(req.symbol, market)
+    message = await _fetch_message_context(db, req.symbol, market)
+
+    holding_line = (
+        f"当前持仓 {cur_q:.0f} 股,成本(单价) {cur_c:.3f}"
+        if is_add
+        else "当前空仓(本次为建仓)"
+    )
+    dilute_line = f",较现成本摊薄 {dilute_abs:.3f}({dilute_pct:.2f}%)" if is_add else ""
+    user_content = (
+        f"标的 {market}:{req.symbol}\n"
+        f"{holding_line}\n"
+        f"拟{action} {add_q:.0f} 股 @ {add_p:.3f}\n"
+        f"{action}后成本(单价) {new_cost:.3f}{dilute_line}\n"
+        + (f"{realtime}\n" if realtime else "")
+        + (f"{fundamental}\n" if fundamental else "")
+        + (f"{technical}\n" if technical else "")
+        + (f"{message}\n" if message else "")
+        + f"请综合估值/基本面与消息面,评估这次{action}是否合适。"
+    )
+    system_prompt = (
+        "你是谨慎务实的股票交易助手。综合用户给出的持仓、价格、基本面、技术面与消息面信息,"
+        f"评估这次{action}是否合适,不臆造数据、不做收益承诺。\n"
+        "严格按以下格式输出,简洁:\n"
+        "结论: 适合 / 谨慎 / 不适合(三选一)\n"
+        "理由:\n- (2~3 条,结合摊薄成本、估值/基本面、技术面与消息面)\n"
+        "风险: (一句话最大风险)"
+    )
+
+    try:
+        client = _get_ai_client(db, req.model_id)
+        content = await client.chat(system_prompt, user_content, temperature=0.3)
+    except Exception as e:
+        raise HTTPException(502, f"AI 评估失败: {e}")
+
+    return {
+        "symbol": req.symbol,
+        "market": market,
+        "action": action,
+        "new_cost": round(new_cost, 4),
+        "dilute_abs": round(dilute_abs, 4),
+        "dilute_pct": round(dilute_pct, 4),
+        "total_quantity": new_q,
+        "total_invested": round(new_q * new_cost, 2),
+        "verdict": _parse_verdict(content),
+        "content": content,
+    }

--- a/tests/test_add_position_eval.py
+++ b/tests/test_add_position_eval.py
@@ -1,0 +1,80 @@
+"""加仓快速评估接口:服务端口径算摊薄成本 + AI 给 适合/谨慎/不适合 结论。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from src.web.api import insights
+from src.web.database import SessionLocal
+
+
+class _FakeAIClient:
+    def __init__(self, reply: str):
+        self._reply = reply
+
+    async def chat(self, system_prompt, user_content, temperature=0.3):
+        return self._reply
+
+
+def _run_eval(monkeypatch, req, reply="结论: 适合\n理由:\n- 摊薄明显\n风险: 大盘转弱"):
+    monkeypatch.setattr(insights, "_get_ai_client", lambda db, mid=None: _FakeAIClient(reply))
+
+    async def _empty(*a, **k):
+        return ""
+
+    monkeypatch.setattr(insights, "_fetch_realtime_context", _empty)
+    monkeypatch.setattr(insights, "_fetch_fundamental_context", _empty)
+    monkeypatch.setattr(insights, "_fetch_technical_context", _empty)
+    monkeypatch.setattr(insights, "_fetch_message_context", _empty)
+    db = SessionLocal()
+    try:
+        return asyncio.run(insights.add_position_eval(req, db))
+    finally:
+        db.close()
+
+
+def test_add_position_eval_computes_diluted_cost(monkeypatch):
+    """加仓 100@8 到 100@10 的持仓:摊薄后成本 9.0(↓10%),并带 AI 结论。"""
+    req = insights.AddPositionEvalRequest(
+        symbol="600519", market="CN",
+        current_quantity=100, current_cost=10,
+        add_quantity=100, add_price=8,
+    )
+    res = _run_eval(monkeypatch, req)
+    assert res["new_cost"] == 9.0
+    assert round(res["dilute_pct"], 1) == 10.0
+    assert res["total_quantity"] == 200
+    assert res["action"] == "加仓"
+    assert res["verdict"] == "适合"
+
+
+def test_build_position_when_empty(monkeypatch):
+    """空仓时为建仓:成本=加仓价,摊薄为 0。"""
+    req = insights.AddPositionEvalRequest(
+        symbol="600519", market="CN",
+        current_quantity=0, current_cost=0,
+        add_quantity=100, add_price=8,
+    )
+    res = _run_eval(monkeypatch, req)
+    assert res["new_cost"] == 8.0
+    assert res["dilute_pct"] == 0
+    assert res["action"] == "建仓"
+
+
+def test_verdict_parse_not_confused_by_substring():
+    """'不适合' 含 '适合',解析必须先长后短,不能误判为 '适合'。"""
+    assert insights._parse_verdict("结论: 不适合\n理由: ...") == "不适合"
+    assert insights._parse_verdict("结论: 谨慎") == "谨慎"
+    assert insights._parse_verdict("结论: 适合") == "适合"
+    assert insights._parse_verdict("看不出来") == "未知"
+
+
+def test_zero_add_quantity_rejected_by_schema():
+    """加仓股数必须 > 0(schema 层拦截)。"""
+    with pytest.raises(ValidationError):
+        insights.AddPositionEvalRequest(
+            symbol="600519", add_quantity=0, add_price=8,
+        )


### PR DESCRIPTION
## 背景

希望在股票详情里很方便地算「加仓后成本能降到多少」,并快速让 AI 评估适不适合加仓(需结合基本面与消息面)。

## 改动

**前端 — 概览页持仓下方「加仓测算」可展开面板**(`add-position-calculator.tsx`,内嵌进 `StockInsightModal`)
- 正算:按 **股数 / 金额**(可切换)+ 加仓价 → 加仓后摊薄成本、摊薄幅度(元/%)、合计股数/投入
- 反推:输入目标成本 → 所需加仓股数/金额(仅 `加仓价 < 目标 < 现成本` 可行;CN 提示按 100 股取整)
- 空仓时退化为「建仓测算」;自动带入当前持仓与现价
- 测算逻辑抽成纯函数(`calcAddPosition` / `calcSharesForTargetCost`)

**后端 — AI 快速评估** `POST /api/insights/add-position-eval`
- 后端按服务端口径算摊薄成本(不信前端)
- 上下文综合:实时行情 + **基本面**(PE/换手/市值/振幅) + 技术面 + **消息面**(近 3 天新闻/公告 + 本地最近 AI 建议/分析)
- 返回 **适合 / 谨慎 / 不适合** + 理由 + 风险,前端内联色块展示
- 复用 chat.py 的 AI client 与上下文构建;K线摘要走已缓存路径

## 测试

- 后端 `pytest tests/` → **288 passed, 1 skipped**(新增 4 项:摊薄计算 / 建仓 / 结论解析先长后短 / schema 校验,mock 掉 AI 与上下文 fetcher)
- 前端 `tsc -b` → 通过