### PR TITLE
M1: 复活 Phase 0-4(回测/真实成本模拟盘/IC/可解释评分/组合诊断)

### DIFF
--- a/frontend/packages/api/src/recommendations.ts
+++ b/frontend/packages/api/src/recommendations.ts
@@ -167,6 +167,11 @@ export interface StrategySignalItem {
     weight?: number
     has_entry_plan?: boolean
   }
+  ai_score?: number
+  factor_explain?: {
+    positive?: { factor: string; label: string; contribution: number }[]
+    negative?: { factor: string; label: string; contribution: number }[]
+  }
   market_regime?: {
     regime?: string
     regime_label?: string

--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -738,6 +738,14 @@ export default function OpportunitiesPage() {
                     <div className={`text-[12px] font-mono mt-1 ${Number(item.rank_score || item.score || 0) >= 80 ? 'text-primary' : 'text-muted-foreground'}`}>
                       评分 {Math.round(item.rank_score || item.score || 0)}
                     </div>
+                    {item.ai_score != null && (
+                      <div className="mt-1 flex items-center justify-end gap-1">
+                        <span className="text-[10px] text-muted-foreground">AI</span>
+                        <span className={`inline-flex items-center justify-center min-w-[18px] px-1.5 py-0.5 rounded text-[11px] font-semibold ${item.ai_score >= 8 ? 'bg-green-500/20 text-green-400' : item.ai_score >= 6 ? 'bg-primary/20 text-primary' : item.ai_score >= 4 ? 'bg-amber-500/20 text-amber-400' : 'bg-red-500/20 text-red-400'}`}>
+                          {item.ai_score}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="mt-2 text-[12px] text-foreground line-clamp-2">{item.signal || item.reason || '--'}</div>
@@ -768,6 +776,20 @@ export default function OpportunitiesPage() {
                   <div>相对强弱: {crossFeature.relative_strength_pct != null ? `${Number(crossFeature.relative_strength_pct).toFixed(0)}分位` : '--'}</div>
                   <div>事件催化: {eventScore != null ? eventScore.toFixed(1) : '--'}{eventCount > 0 ? `（${eventCount}条）` : '（无命中）'}</div>
                 </div>
+                {item.factor_explain && (((item.factor_explain.positive?.length ?? 0) > 0) || ((item.factor_explain.negative?.length ?? 0) > 0)) && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {(item.factor_explain.positive ?? []).map((f) => (
+                      <span key={`p-${f.factor}`} className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-green-500/15 text-green-400">
+                        {f.label} +{Math.abs(f.contribution).toFixed(1)}
+                      </span>
+                    ))}
+                    {(item.factor_explain.negative ?? []).map((f) => (
+                      <span key={`n-${f.factor}`} className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-red-500/15 text-red-400">
+                        {f.label} {f.contribution.toFixed(1)}
+                      </span>
+                    ))}
+                  </div>
+                )}
                 {item.constrained && (
                   <div className="mt-2 text-[10px] text-amber-400">
                     组合约束: {(item.constraint_reasons || []).join('；') || '已自动降级'}

--- a/src/core/backtest/__init__.py
+++ b/src/core/backtest/__init__.py
@@ -1,0 +1,38 @@
+"""PanWatch 回测模块(Phase 0 地基)。
+
+轻量、纯 Python、零第三方依赖的事件式回测内核,服务于:
+- 历史验证现有 StrategySignalRun 信号的真实表现
+- 为 Phase 2 的因子 IC/IR 与回测驱动调权提供真值
+- 与模拟盘(Phase 1)共用 A 股交易成本模型
+
+vectorbt 作为未来可选的向量化升级路径(见 .docs/quant-framework-comparison.md)。
+"""
+
+from src.core.backtest.cost_model import CostConfig, CostModel, DEFAULT_COST_MODEL, Fill
+from src.core.backtest.data_adapter import PriceBar, from_klines, load_price_history
+from src.core.backtest.engine import (
+    Backtester,
+    BacktestResult,
+    BTTrade,
+    Signal,
+    fixed_cash_sizer,
+    horizon_return,
+)
+from src.core.backtest import metrics
+
+__all__ = [
+    "CostConfig",
+    "CostModel",
+    "DEFAULT_COST_MODEL",
+    "Fill",
+    "PriceBar",
+    "from_klines",
+    "load_price_history",
+    "Backtester",
+    "BacktestResult",
+    "BTTrade",
+    "Signal",
+    "fixed_cash_sizer",
+    "horizon_return",
+    "metrics",
+]

--- a/src/core/backtest/cost_model.py
+++ b/src/core/backtest/cost_model.py
@@ -1,0 +1,127 @@
+"""A 股交易成本模型 —— 回测(Phase 0)与模拟盘(Phase 1)共用。
+
+成本口径(2023-08-28 印花税下调后):
+- 印花税:**卖出单边** 0.05%(万 5)
+- 佣金:双边,默认万 2.5,单笔最低 5 元
+- 过户费:双边,成交额 0.001%(沪深统一,2022-04 起)
+- 滑点:可配置基点(默认 5bps),买入价上滑 / 卖出价下滑,模拟冲击成本
+
+滑点体现在实际成交价(fill_price),不重复计入显式规费;显式规费 = 佣金+印花税+过户费。
+现金变动(cash_delta)= 买入为负、卖出为正,已扣全部成本与滑点,PnL 由买卖两腿 cash_delta 相加得出。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CostConfig:
+    """成本参数(可配置;默认值贴近 A 股散户实际)。"""
+
+    commission_rate: float = 0.00025   # 佣金费率(双边)万 2.5
+    min_commission: float = 5.0        # 单笔最低佣金(元)
+    stamp_duty_rate: float = 0.0005    # 印花税(仅卖出)万 5
+    transfer_fee_rate: float = 0.00001  # 过户费(双边)十万分之 1
+    slippage_bps: float = 5.0          # 滑点(基点,双边;5bps = 0.05%)
+
+
+@dataclass(frozen=True)
+class Fill:
+    """一次成交的净结果(含成本拆解,便于展示与审计)。"""
+
+    side: str            # "buy" | "sell"
+    price: float         # 名义价(信号/行情价,未含滑点)
+    fill_price: float    # 实际成交价(含滑点)
+    quantity: int
+    gross: float         # 实际成交额 = fill_price * quantity
+    commission: float
+    stamp_duty: float
+    transfer_fee: float
+    slippage_cost: float  # 滑点损耗 = |fill_price - price| * quantity(仅展示)
+    explicit_fees: float  # 显式规费 = commission + stamp_duty + transfer_fee
+    friction: float       # 总摩擦 = explicit_fees + slippage_cost(仅展示)
+    cash_delta: float     # 现金变动:buy 为负,sell 为正(已扣显式规费;滑点含在 fill_price)
+
+
+class CostModel:
+    """A 股交易成本计算器。线程无关,可全局复用。"""
+
+    def __init__(self, config: CostConfig | None = None) -> None:
+        self.cfg = config or CostConfig()
+
+    def _apply_slippage(self, price: float, side: str) -> float:
+        adj = price * self.cfg.slippage_bps / 10000.0
+        return price + adj if side == "buy" else max(0.0, price - adj)
+
+    def fill(self, side: str, price: float, quantity: int) -> Fill:
+        """计算一笔成交的成本与现金变动。
+
+        Args:
+            side: "buy" 或 "sell"
+            price: 名义价(未含滑点)
+            quantity: 股数(正整数)
+        """
+        side = (side or "").strip().lower()
+        if side not in ("buy", "sell"):
+            raise ValueError(f"side 必须是 buy/sell,得到 {side!r}")
+        qty = int(quantity)
+        if qty <= 0 or price <= 0:
+            raise ValueError(f"price/quantity 必须为正,得到 price={price} qty={quantity}")
+
+        fill_price = self._apply_slippage(price, side)
+        gross = fill_price * qty
+        commission = max(gross * self.cfg.commission_rate, self.cfg.min_commission)
+        stamp_duty = gross * self.cfg.stamp_duty_rate if side == "sell" else 0.0
+        transfer_fee = gross * self.cfg.transfer_fee_rate
+        slippage_cost = abs(fill_price - price) * qty
+        explicit_fees = commission + stamp_duty + transfer_fee
+
+        if side == "buy":
+            cash_delta = -(gross + explicit_fees)
+        else:
+            cash_delta = gross - explicit_fees
+
+        return Fill(
+            side=side,
+            price=float(price),
+            fill_price=round(fill_price, 6),
+            quantity=qty,
+            gross=round(gross, 4),
+            commission=round(commission, 4),
+            stamp_duty=round(stamp_duty, 4),
+            transfer_fee=round(transfer_fee, 4),
+            slippage_cost=round(slippage_cost, 4),
+            explicit_fees=round(explicit_fees, 4),
+            friction=round(explicit_fees + slippage_cost, 4),
+            cash_delta=round(cash_delta, 4),
+        )
+
+    def round_trip_pnl(
+        self, entry_price: float, exit_price: float, quantity: int
+    ) -> dict:
+        """一买一卖的完整盈亏(扣全部成本)。便于单笔回测与对账。"""
+        buy = self.fill("buy", entry_price, quantity)
+        sell = self.fill("sell", exit_price, quantity)
+        # 现金口径:买入流出 -cash_delta(正数),卖出流入 cash_delta
+        invested = -buy.cash_delta
+        proceeds = sell.cash_delta
+        pnl = proceeds - invested
+        pnl_pct = (pnl / invested * 100.0) if invested > 0 else 0.0
+        total_cost = buy.friction + sell.friction
+        return {
+            "entry_price": float(entry_price),
+            "exit_price": float(exit_price),
+            "quantity": int(quantity),
+            "invested": round(invested, 4),
+            "proceeds": round(proceeds, 4),
+            "pnl": round(pnl, 4),
+            "pnl_pct": round(pnl_pct, 4),
+            "total_cost": round(total_cost, 4),
+            "buy": buy,
+            "sell": sell,
+        }
+
+
+# 全局默认实例(可被覆盖配置)
+DEFAULT_COST_MODEL = CostModel()

--- a/src/core/backtest/data_adapter.py
+++ b/src/core/backtest/data_adapter.py
@@ -1,0 +1,71 @@
+"""回测数据适配:KlineCollector → PriceBar,交易日历对齐。
+
+- PriceBar 定义在本模块顶层,且 **不在顶层 import KlineCollector**(延迟导入),
+  使回测内核与单测不被 httpx/网络库耦合,可离线运行。
+- KlineCollector 返回的已是前复权(qfq)日线,停牌日天然无 bar,交易日历 = 实际 bar 序列。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PriceBar:
+    """单根日 K(前复权)。"""
+
+    date: str  # YYYY-MM-DD
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+def from_klines(klines) -> list[PriceBar]:
+    """KlineData 列表 → 按日期升序的 PriceBar 列表。"""
+    out: list[PriceBar] = []
+    for k in klines or []:
+        try:
+            out.append(
+                PriceBar(
+                    date=str(k.date)[:10],
+                    open=float(k.open),
+                    high=float(k.high),
+                    low=float(k.low),
+                    close=float(k.close),
+                    volume=float(k.volume or 0),
+                )
+            )
+        except Exception:
+            continue
+    out.sort(key=lambda b: b.date)
+    return out
+
+
+def load_price_history(symbol: str, market, days: int = 250) -> list[PriceBar]:
+    """走 KlineCollector 拉历史(延迟导入,避免顶层耦合网络库)。"""
+    from src.collectors.kline_collector import KlineCollector
+    from src.models.market import MarketCode
+
+    try:
+        mc = market if isinstance(market, MarketCode) else MarketCode(str(market).upper())
+    except Exception:
+        mc = MarketCode.CN
+    try:
+        klines = KlineCollector(mc).get_klines(symbol, days=days)
+    except Exception as e:
+        logger.warning(f"[回测] 拉取 {symbol} K线失败: {e}")
+        return []
+    return from_klines(klines)
+
+
+def first_index_after(bars: list[PriceBar], date: str) -> int | None:
+    """返回第一个 date 严格大于给定日期的 bar 下标(下一交易日,防 look-ahead)。"""
+    for i, b in enumerate(bars):
+        if b.date > date:
+            return i
+    return None

--- a/src/core/backtest/engine.py
+++ b/src/core/backtest/engine.py
@@ -1,0 +1,231 @@
+"""轻量事件式回测内核(纯 Python,无第三方依赖)。
+
+职责:给定信号 + 历史 K 线 → 模拟「信号次日开盘入场、逐日止损/止盈/到期平仓」,
+扣 A 股交易成本,产出每笔交易、净值曲线与绩效指标。
+
+设计取舍(Phase 0):
+- 入场:信号日之后的**下一交易日开盘价**入场(无未来函数);T+1 起才可平仓(符合 A 股)。
+- 平仓(event):逐日检查止损/止盈;同日双触保守判为先止损;达最大持有交易日按收盘平。
+- 跳空:开盘已越过止损/止盈则按开盘价成交(gap)。
+- 仓位:默认每笔固定名义资金,买 A 股 100 股整数倍(可注入 sizer 供 Phase 1 替换)。
+- 净值曲线:按平仓日累积已实现盈亏(简化);并发持仓的逐日浮动 mark 留作后续扩展。
+- 涨跌停无法成交约束未建模(TODO:需前收 + 板块判定)。
+
+另提供 horizon_return():复刻 strategy_engine.evaluate_strategy_outcomes 口径,用于交叉验证。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable
+
+from src.core.backtest import metrics as M
+from src.core.backtest.cost_model import CostModel
+from src.core.backtest.data_adapter import PriceBar, first_index_after
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Signal:
+    """一条待回测信号(对齐 StrategySignalRun 的可执行字段)。"""
+
+    symbol: str
+    market: str
+    signal_date: str                  # YYYY-MM-DD(信号产生日)
+    entry_price: float | None = None  # None = 用下一交易日开盘价
+    stop_loss: float | None = None
+    target_price: float | None = None
+    holding_days: int = 10            # 最大持有交易日(event 模式)
+
+
+@dataclass
+class BTTrade:
+    symbol: str
+    market: str
+    entry_date: str
+    entry_price: float
+    exit_date: str
+    exit_price: float
+    quantity: int
+    pnl: float
+    pnl_pct: float
+    fees: float
+    exit_reason: str  # stop_loss | target | expire | eod
+    holding_bars: int
+
+
+@dataclass
+class BacktestResult:
+    trades: list[BTTrade]
+    equity_curve: list[float]
+    equity_dates: list[str]
+    metrics: dict
+    initial_capital: float
+    skipped: int = 0
+
+
+PositionSizer = Callable[[float], int]  # price -> qty
+
+
+def fixed_cash_sizer(cash_per_trade: float, lot: int = 100) -> PositionSizer:
+    """每笔固定名义资金,买入 lot 的整数倍。"""
+
+    def _size(price: float) -> int:
+        if price <= 0:
+            return 0
+        lots = int((cash_per_trade / price) // lot)
+        return max(0, lots * lot)
+
+    return _size
+
+
+def _parse_day(s):
+    try:
+        return datetime.strptime(str(s)[:10], "%Y-%m-%d").date()
+    except Exception:
+        return None
+
+
+class Backtester:
+    def __init__(
+        self,
+        cost_model: CostModel | None = None,
+        initial_capital: float = 1_000_000.0,
+        cash_per_trade: float = 100_000.0,
+        lot: int = 100,
+        sizer: PositionSizer | None = None,
+    ) -> None:
+        self.cost = cost_model or CostModel()
+        self.initial_capital = float(initial_capital)
+        self.sizer = sizer or fixed_cash_sizer(cash_per_trade, lot)
+
+    def run_single(self, signal: Signal, bars: list[PriceBar]) -> BTTrade | None:
+        """单信号回测:下一交易日开盘入场,逐日止损/止盈/到期平仓。"""
+        if not bars:
+            return None
+        ei = first_index_after(bars, signal.signal_date)
+        if ei is None or ei >= len(bars):
+            return None
+        entry_bar = bars[ei]
+        entry_price = entry_bar.open if signal.entry_price is None else float(signal.entry_price)
+        if entry_price <= 0:
+            return None
+        qty = self.sizer(entry_price)
+        if qty <= 0:
+            return None
+
+        stop = signal.stop_loss
+        target = signal.target_price
+        max_hold = max(1, int(signal.holding_days or 10))
+
+        exit_price = exit_date = exit_reason = None
+        held = 0
+        # T+1 起逐日检查(入场日当天不可卖)
+        for j in range(ei + 1, len(bars)):
+            held = j - ei
+            bar = bars[j]
+            if stop and stop > 0:
+                if bar.open <= stop:  # 跳空跌破
+                    exit_price, exit_date, exit_reason = bar.open, bar.date, "stop_loss"
+                    break
+                if bar.low <= stop:
+                    exit_price, exit_date, exit_reason = stop, bar.date, "stop_loss"
+                    break
+            if target and target > 0:
+                if bar.open >= target:  # 跳空冲高
+                    exit_price, exit_date, exit_reason = bar.open, bar.date, "target"
+                    break
+                if bar.high >= target:
+                    exit_price, exit_date, exit_reason = target, bar.date, "target"
+                    break
+            if held >= max_hold:
+                exit_price, exit_date, exit_reason = bar.close, bar.date, "expire"
+                break
+
+        if exit_price is None:
+            last = bars[-1]
+            exit_price, exit_date, exit_reason = last.close, last.date, "eod"
+            held = len(bars) - 1 - ei
+
+        rt = self.cost.round_trip_pnl(entry_price, exit_price, qty)
+        return BTTrade(
+            symbol=signal.symbol,
+            market=signal.market,
+            entry_date=entry_bar.date,
+            entry_price=round(entry_price, 4),
+            exit_date=exit_date,
+            exit_price=round(exit_price, 4),
+            quantity=qty,
+            pnl=rt["pnl"],
+            pnl_pct=rt["pnl_pct"],
+            fees=rt["total_cost"],
+            exit_reason=exit_reason,
+            holding_bars=held,
+        )
+
+    def run(
+        self, signals: list[Signal], bars_by_symbol: dict
+    ) -> BacktestResult:
+        """批量回测,聚合净值曲线与绩效指标。
+
+        bars_by_symbol: 键可为 (symbol, market) 或 symbol。
+        """
+        trades: list[BTTrade] = []
+        skipped = 0
+        for sig in signals:
+            bars = bars_by_symbol.get((sig.symbol, sig.market)) or bars_by_symbol.get(sig.symbol)
+            if not bars:
+                skipped += 1
+                continue
+            t = self.run_single(sig, bars)
+            if t is None:
+                skipped += 1
+                continue
+            trades.append(t)
+
+        trades_sorted = sorted(trades, key=lambda t: t.exit_date)
+        equity = self.initial_capital
+        curve = [self.initial_capital]
+        dates = [""]
+        for t in trades_sorted:
+            equity += t.pnl
+            curve.append(round(equity, 4))
+            dates.append(t.exit_date)
+
+        pnls = [t.pnl for t in trades]
+        return BacktestResult(
+            trades=trades,
+            equity_curve=curve,
+            equity_dates=dates,
+            metrics=M.summarize(curve, pnls),
+            initial_capital=self.initial_capital,
+            skipped=skipped,
+        )
+
+
+def horizon_return(signal: Signal, bars: list[PriceBar], horizon_days: int) -> float | None:
+    """复刻 strategy_engine.evaluate_strategy_outcomes 口径,用于交叉验证。
+
+    base = signal.entry_price;target_day = signal_date + horizon_days(自然日);
+    outcome = 最近 <= target_day 的收盘价;return% = (outcome-base)/base*100。
+    """
+    snap = _parse_day(signal.signal_date)
+    base = signal.entry_price
+    if snap is None or not bars or not base or base <= 0:
+        return None
+    target_day = snap + timedelta(days=int(horizon_days))
+    outcome = None
+    for b in bars:
+        d = _parse_day(b.date)
+        if d is None:
+            continue
+        if d <= target_day:
+            outcome = b.close
+        else:
+            break
+    if outcome is None:
+        return None
+    return (outcome - base) / base * 100.0

--- a/src/core/backtest/metrics.py
+++ b/src/core/backtest/metrics.py
@@ -1,0 +1,116 @@
+"""回测绩效指标 —— 纯函数,仅依赖标准库。
+
+约定:
+- equity_curve: list[float],逐(交易日)净值序列(含浮动盈亏),首元素为期初资金。
+- trade_pnls: list[float],每笔已平仓交易的净盈亏(已扣成本)。
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+def daily_returns(equity_curve: list[float]) -> list[float]:
+    """由净值序列推日收益率。"""
+    out: list[float] = []
+    for i in range(1, len(equity_curve)):
+        prev = equity_curve[i - 1]
+        if prev and prev > 0:
+            out.append(equity_curve[i] / prev - 1.0)
+        else:
+            out.append(0.0)
+    return out
+
+
+def total_return(equity_curve: list[float]) -> float:
+    if len(equity_curve) < 2 or not equity_curve[0]:
+        return 0.0
+    return equity_curve[-1] / equity_curve[0] - 1.0
+
+
+def annualized_return(
+    equity_curve: list[float], periods_per_year: int = TRADING_DAYS_PER_YEAR
+) -> float:
+    n = len(equity_curve) - 1
+    if n <= 0 or not equity_curve[0] or equity_curve[0] <= 0 or equity_curve[-1] <= 0:
+        return 0.0
+    growth = equity_curve[-1] / equity_curve[0]
+    return growth ** (periods_per_year / n) - 1.0
+
+
+def max_drawdown(equity_curve: list[float]) -> float:
+    """最大回撤(正数,如 0.23 表示 -23%)。"""
+    if len(equity_curve) < 2:
+        return 0.0
+    peak = equity_curve[0]
+    mdd = 0.0
+    for v in equity_curve:
+        if v > peak:
+            peak = v
+        if peak > 0:
+            dd = (peak - v) / peak
+            if dd > mdd:
+                mdd = dd
+    return mdd
+
+
+def sharpe(
+    returns: list[float],
+    risk_free: float = 0.0,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+) -> float:
+    """年化夏普(样本标准差)。returns 为周期收益率序列。"""
+    if len(returns) < 2:
+        return 0.0
+    rf_per_period = risk_free / periods_per_year
+    excess = [r - rf_per_period for r in returns]
+    mean = statistics.fmean(excess)
+    sd = statistics.stdev(excess)
+    if sd == 0:
+        return 0.0
+    return mean / sd * math.sqrt(periods_per_year)
+
+
+def win_rate(trade_pnls: list[float]) -> float:
+    if not trade_pnls:
+        return 0.0
+    wins = sum(1 for p in trade_pnls if p > 0)
+    return wins / len(trade_pnls)
+
+
+def profit_factor(trade_pnls: list[float]) -> float:
+    """盈亏比 = 总盈利 / 总亏损(绝对值)。无亏损时返回 inf。"""
+    gains = sum(p for p in trade_pnls if p > 0)
+    losses = -sum(p for p in trade_pnls if p < 0)
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / losses
+
+
+def avg_win_loss(trade_pnls: list[float]) -> tuple[float, float]:
+    wins = [p for p in trade_pnls if p > 0]
+    losses = [p for p in trade_pnls if p < 0]
+    avg_w = statistics.fmean(wins) if wins else 0.0
+    avg_l = statistics.fmean(losses) if losses else 0.0
+    return avg_w, avg_l
+
+
+def summarize(equity_curve: list[float], trade_pnls: list[float]) -> dict:
+    """汇总所有绩效指标为一个 dict。"""
+    rets = daily_returns(equity_curve)
+    avg_w, avg_l = avg_win_loss(trade_pnls)
+    return {
+        "total_return": round(total_return(equity_curve), 6),
+        "annualized_return": round(annualized_return(equity_curve), 6),
+        "max_drawdown": round(max_drawdown(equity_curve), 6),
+        "sharpe": round(sharpe(rets), 4),
+        "trades": len(trade_pnls),
+        "win_rate": round(win_rate(trade_pnls), 4),
+        "profit_factor": round(profit_factor(trade_pnls), 4),
+        "avg_win": round(avg_w, 4),
+        "avg_loss": round(avg_l, 4),
+        "total_pnl": round(sum(trade_pnls), 4),
+    }

--- a/src/core/context_scheduler.py
+++ b/src/core/context_scheduler.py
@@ -100,6 +100,24 @@ class ContextMaintenanceScheduler:
                 rebalance.get("checked", 0),
                 rebalance.get("skipped_low_sample", 0),
             )
+
+            # Phase 4: 因子 IC/IR 评估纳入定时闭环(只评估+记录,供调权与机会页参考)
+            try:
+                from src.core.factor_eval import evaluate_factor_ic
+
+                ic = await asyncio.to_thread(evaluate_factor_ic, days=90, horizon=5)
+                ics = {
+                    k: v.get("ic")
+                    for k, v in ic.get("factors", {}).items()
+                    if v.get("ic") is not None
+                }
+                logger.log(
+                    logging.INFO if ics else logging.DEBUG,
+                    "[上下文维护] 因子IC评估完成: %s",
+                    ics,
+                )
+            except Exception as ic_err:
+                logger.debug("[上下文维护] 因子IC评估跳过: %s", ic_err)
         except Exception as e:
             logger.exception(f"[上下文维护] 后验评估异常: {e}")
         finally:

--- a/src/core/factor_eval.py
+++ b/src/core/factor_eval.py
@@ -1,0 +1,153 @@
+"""因子有效性评估(Phase 2):IC / IR。
+
+回答「哪些因子在 A 股真正有 alpha」—— 把 StrategyFactorSnapshot(每个信号的因子分)
+与 StrategyOutcome(前向收益)按 signal_run_id 关联,算每个因子的:
+- IC(信息系数):因子值与未来收益的 Spearman 秩相关(全样本)
+- IR(信息比率):按快照日分组的 IC 序列的 mean/std
+
+纯 Python 实现相关系数(不引入 scipy/alphalens),与回测内核一致的轻量约束。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from statistics import fmean, stdev
+
+from src.web.database import SessionLocal
+from src.web.models import StrategyFactorSnapshot, StrategyOutcome
+
+logger = logging.getLogger(__name__)
+
+# 参与评估的因子字段(对应 StrategyFactorSnapshot 列)
+FACTOR_FIELDS = (
+    "alpha_score",
+    "catalyst_score",
+    "quality_score",
+    "risk_penalty",   # 惩罚项,IC 预期为负
+    "crowd_penalty",  # 惩罚项,IC 预期为负
+    "final_score",
+)
+
+
+def pearson(xs: list[float], ys: list[float]) -> float | None:
+    """Pearson 线性相关系数;样本 < 3 或零方差返回 None。"""
+    n = len(xs)
+    if n < 3 or n != len(ys):
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    vx = sum((x - mx) ** 2 for x in xs)
+    vy = sum((y - my) ** 2 for y in ys)
+    if vx <= 0 or vy <= 0:
+        return None
+    return cov / (vx ** 0.5 * vy ** 0.5)
+
+
+def _rankdata(values: list[float]) -> list[float]:
+    """平均秩(1-based;并列取平均)。"""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def spearman(xs: list[float], ys: list[float]) -> float | None:
+    """Spearman 秩相关 = 对秩做 Pearson。"""
+    if len(xs) < 3 or len(xs) != len(ys):
+        return None
+    return pearson(_rankdata(xs), _rankdata(ys))
+
+
+def evaluate_factor_ic(
+    *, days: int = 90, horizon: int = 5, min_samples: int = 20, min_period_samples: int = 5
+) -> dict:
+    """计算各因子的 IC/IR。
+
+    Args:
+        days: 回看快照天数
+        horizon: 用哪个持有期(交易日)的 outcome
+        min_samples: 全样本 IC 的最小样本量
+        min_period_samples: 单日 IC 的最小样本量(用于 IR 的时序序列)
+    """
+    db = SessionLocal()
+    try:
+        cutoff = (date.today() - timedelta(days=max(7, int(days)))).strftime("%Y-%m-%d")
+        rows = (
+            db.query(StrategyFactorSnapshot, StrategyOutcome.outcome_return_pct)
+            .join(
+                StrategyOutcome,
+                StrategyFactorSnapshot.signal_run_id == StrategyOutcome.signal_run_id,
+            )
+            .filter(
+                StrategyOutcome.horizon_days == int(horizon),
+                StrategyOutcome.outcome_status.in_(("evaluated", "hit_target", "hit_stop")),
+                StrategyOutcome.outcome_return_pct.isnot(None),
+                StrategyFactorSnapshot.snapshot_date >= cutoff,
+            )
+            .all()
+        )
+
+        all_xy: dict[str, tuple[list[float], list[float]]] = {f: ([], []) for f in FACTOR_FIELDS}
+        by_date: dict[str, dict[str, tuple[list[float], list[float]]]] = {}
+
+        for snap, ret in rows:
+            try:
+                r = float(ret)
+            except Exception:
+                continue
+            for f in FACTOR_FIELDS:
+                v = getattr(snap, f, None)
+                if v is None:
+                    continue
+                try:
+                    fv = float(v)
+                except Exception:
+                    continue
+                all_xy[f][0].append(fv)
+                all_xy[f][1].append(r)
+                d = snap.snapshot_date or ""
+                slot = by_date.setdefault(d, {}).setdefault(f, ([], []))
+                slot[0].append(fv)
+                slot[1].append(r)
+
+        factors: dict[str, dict] = {}
+        for f in FACTOR_FIELDS:
+            xs, ys = all_xy[f]
+            ic = spearman(xs, ys) if len(xs) >= min_samples else None
+            period_ics: list[float] = []
+            for _d, facmap in by_date.items():
+                if f not in facmap:
+                    continue
+                pxs, pys = facmap[f]
+                if len(pxs) >= min_period_samples:
+                    di = spearman(pxs, pys)
+                    if di is not None:
+                        period_ics.append(di)
+            ir = None
+            if len(period_ics) >= 3:
+                m = fmean(period_ics)
+                s = stdev(period_ics)
+                ir = (m / s) if s > 0 else None
+            factors[f] = {
+                "ic": round(ic, 4) if ic is not None else None,
+                "ir": round(ir, 4) if ir is not None else None,
+                "sample_size": len(xs),
+                "ic_periods": len(period_ics),
+            }
+
+        return {"horizon": int(horizon), "days": int(days), "factors": factors}
+    except Exception as e:
+        logger.warning(f"[因子评估] IC 计算失败: {e}")
+        return {"horizon": int(horizon), "days": int(days), "factors": {}, "error": str(e)}
+    finally:
+        db.close()

--- a/src/core/paper_trading_engine.py
+++ b/src/core/paper_trading_engine.py
@@ -19,10 +19,60 @@ from src.web.models import (
     PaperTradingTrade,
     StrategySignalRun,
 )
+from src.core.backtest.cost_model import CostModel
 
 logger = logging.getLogger(__name__)
 
+# 模拟盘交易成本(A股口径,Phase 1)。与回测共用同一成本模型。
+COST_MODEL = CostModel()
+
+# 建仓股数下限(A股一手)
 FIXED_QUANTITY = 100
+
+# 移动止损:浮盈超过 MIN_PROFIT_FOR_TRAILING 后启用,从持仓最高价回撤超 TRAILING_STOP_PCT 即离场
+MIN_PROFIT_FOR_TRAILING = 0.05
+TRAILING_STOP_PCT = 0.10
+# 时间止损:无 signal.holding_days 时的默认最大持有自然日
+DEFAULT_TIME_STOP_DAYS = 20
+
+
+def _position_weight(rank_score: float) -> float:
+    """按信号强度分配单笔资金占该市场预算的比例(rank_score 越高投越多)。"""
+    s = float(rank_score or 0.0)
+    if s >= 85:
+        return 0.25
+    if s >= 75:
+        return 0.18
+    if s >= 65:
+        return 0.12
+    return 0.08
+
+
+def _compute_quantity(
+    *,
+    rank_score: float,
+    market_budget: float,
+    price: float,
+    available_cash: float,
+    cost_model: CostModel,
+    lot: int = FIXED_QUANTITY,
+) -> int:
+    """按信号强度 + 市场预算计算建仓股数(lot 整数倍),受可用现金(含买入费)约束。
+
+    返回 0 表示连最小一手都买不起,应跳过。
+    """
+    if price <= 0:
+        return 0
+    target_cash = max(0.0, market_budget) * _position_weight(rank_score)
+    qty = int((target_cash / price) // lot) * lot
+    if qty < lot:
+        qty = lot  # 至少一手
+    while qty >= lot:
+        outlay = -cost_model.fill("buy", price, qty).cash_delta
+        if outlay <= available_cash:
+            return qty
+        qty -= lot
+    return 0
 
 
 def _utc_now() -> datetime:
@@ -296,12 +346,26 @@ class PaperTradingEngine:
 
             # 用当前市价入场
             entry_price = current_price
-            cost = entry_price * FIXED_QUANTITY
             mkt = sig.stock_market
             if alloc.get(mkt, 0.0) <= 0:
                 continue  # 该市场比例为 0，不投入
-            if cost > market_cash.get(mkt, 0.0):
-                continue  # 该市场子池额度不足
+            avail = market_cash.get(mkt, 0.0)
+
+            # 仓位管理:按信号强度分配该市场预算(替换原固定 100 股)
+            market_budget = account.initial_capital * alloc.get(mkt, 0.0)
+            quantity = _compute_quantity(
+                rank_score=float(sig.rank_score or 0.0),
+                market_budget=market_budget,
+                price=entry_price,
+                available_cash=avail,
+                cost_model=COST_MODEL,
+            )
+            if quantity <= 0:
+                continue  # 子池额度不足以买入最小一手
+
+            # 含交易成本的实际买入流出
+            buy_fill = COST_MODEL.fill("buy", entry_price, quantity)
+            buy_outlay = -buy_fill.cash_delta
 
             # 基于入场价计算止损/止盈
             # 优先用信号的止损/止盈比例，否则用默认 -8%/+15%
@@ -326,11 +390,12 @@ class PaperTradingEngine:
                 stock_symbol=sig.stock_symbol,
                 stock_market=sig.stock_market,
                 stock_name=sig.stock_name or "",
-                quantity=FIXED_QUANTITY,
+                quantity=quantity,
                 entry_price=entry_price,
                 stop_loss=stop_loss,
                 target_price=target_price,
                 current_price=current_price,
+                highest_price=entry_price,
                 unrealized_pnl=0.0,
                 status="open",
                 signal_run_id=sig.id,
@@ -339,19 +404,21 @@ class PaperTradingEngine:
                 strategy_code=sig.strategy_code or "",
             )
             db.add(pos)
-            account.current_capital -= cost
-            market_cash[mkt] = market_cash.get(mkt, 0.0) - cost
+            account.current_capital -= buy_outlay
+            market_cash[mkt] = avail - buy_outlay
             open_keys.add((sig.stock_symbol, sig.stock_market))
             new_keys.add((sig.stock_symbol, sig.stock_market))
             entry_events.append((pos, sig))
             opened += 1
             logger.info(
-                "[模拟盘] 建仓: %s %s @ %.2f, 止损=%.2f, 止盈=%s, 策略=%s",
+                "[模拟盘] 建仓: %s %s @ %.2f x%d, 止损=%.2f, 止盈=%s, 买入费=%.2f, 策略=%s",
                 sig.stock_name or sig.stock_symbol,
                 sig.stock_market,
                 entry_price,
-                sig.stop_loss or 0,
-                sig.target_price or "无",
+                quantity,
+                stop_loss or 0,
+                target_price or "无",
+                buy_fill.explicit_fees + buy_fill.slippage_cost,
                 sig.strategy_code,
             )
 
@@ -369,8 +436,12 @@ class PaperTradingEngine:
     ) -> PaperTradingTrade:
         """平仓单个持仓，返回交易记录。"""
         now = _utc_now()
-        pnl = (exit_price - pos.entry_price) * pos.quantity
-        pnl_pct = ((exit_price - pos.entry_price) / pos.entry_price * 100) if pos.entry_price > 0 else 0.0
+        # 含交易成本的净盈亏:卖出净回收 − 建仓含费投入(与建仓口径一致,资金守恒)
+        buy_cost = -COST_MODEL.fill("buy", pos.entry_price, pos.quantity).cash_delta
+        sell_fill = COST_MODEL.fill("sell", exit_price, pos.quantity)
+        sell_proceeds = sell_fill.cash_delta
+        pnl = round(sell_proceeds - buy_cost, 4)
+        pnl_pct = (pnl / buy_cost * 100) if buy_cost > 0 else 0.0
 
         holding_days = 0
         if pos.opened_at:
@@ -403,8 +474,8 @@ class PaperTradingEngine:
         pos.current_price = exit_price
         pos.unrealized_pnl = pnl
 
-        # 回收资金
-        account.current_capital += exit_price * pos.quantity
+        # 回收资金(卖出净回收,已扣卖出费)
+        account.current_capital += sell_proceeds
         account.total_pnl += pnl
         account.total_trades += 1
         if pnl > 0:
@@ -450,9 +521,13 @@ class PaperTradingEngine:
             if current_price is None or current_price <= 0:
                 continue
 
-            # 更新现价和浮动盈亏
+            # 更新现价、净浮动盈亏(含若此刻平仓的双边成本)、持仓期最高价
             pos.current_price = current_price
-            pos.unrealized_pnl = (current_price - pos.entry_price) * pos.quantity
+            _buy_cost_u = -COST_MODEL.fill("buy", pos.entry_price, pos.quantity).cash_delta
+            _sell_u = COST_MODEL.fill("sell", current_price, pos.quantity).cash_delta
+            pos.unrealized_pnl = round(_sell_u - _buy_cost_u, 4)
+            if pos.highest_price is None or current_price > pos.highest_price:
+                pos.highest_price = current_price
 
             # 检查止损
             if pos.stop_loss and current_price <= pos.stop_loss:
@@ -468,6 +543,17 @@ class PaperTradingEngine:
                 closed += 1
                 continue
 
+            # 移动止损:浮盈达标后,从持仓最高价回撤超阈值则离场
+            if pos.highest_price and pos.entry_price > 0:
+                profit_ratio = (pos.highest_price - pos.entry_price) / pos.entry_price
+                if profit_ratio >= MIN_PROFIT_FOR_TRAILING:
+                    trail_line = pos.highest_price * (1 - TRAILING_STOP_PCT)
+                    if current_price <= trail_line:
+                        trade = self._close_position(db, account, pos, current_price, "trailing_stop")
+                        exit_events.append((pos, trade))
+                        closed += 1
+                        continue
+
             # 检查信号反转
             if pos.signal_run_id:
                 latest = (
@@ -482,6 +568,26 @@ class PaperTradingEngine:
                 )
                 if latest and latest.action in ("sell", "reduce"):
                     trade = self._close_position(db, account, pos, current_price, "signal_reversal")
+                    exit_events.append((pos, trade))
+                    closed += 1
+                    continue
+
+            # 时间止损:持有超过最大自然日离场(优先用 signal 的 holding_days)
+            max_days = DEFAULT_TIME_STOP_DAYS
+            if pos.signal_run_id:
+                sig_hold = (
+                    db.query(StrategySignalRun.holding_days)
+                    .filter(StrategySignalRun.id == pos.signal_run_id)
+                    .scalar()
+                )
+                if sig_hold and int(sig_hold) > 0:
+                    max_days = int(sig_hold)
+            if pos.opened_at:
+                opened_dt = pos.opened_at
+                if opened_dt.tzinfo is None:
+                    opened_dt = opened_dt.replace(tzinfo=timezone.utc)
+                if (_utc_now() - opened_dt).days >= max_days:
+                    trade = self._close_position(db, account, pos, current_price, "time_stop")
                     exit_events.append((pos, trade))
                     closed += 1
                     continue

--- a/src/core/portfolio_diagnostics.py
+++ b/src/core/portfolio_diagnostics.py
@@ -1,0 +1,111 @@
+"""组合诊断(Phase 4):只读分析模拟盘持仓的集中度 / 分布 / 风险。
+
+对标 PortfolioPilot 的「只读不下单」诊断 —— 纯读取持仓,**绝不下单**,只产出诊断与提示。
+纯函数 diagnose_positions 可单测;diagnose_paper_portfolio 读 DB。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.web.database import SessionLocal
+from src.web.models import PaperTradingPosition
+
+logger = logging.getLogger(__name__)
+
+# 风险阈值(可后续配置化)
+MAX_SINGLE_WEIGHT = 0.40   # 单仓占比上限
+HIGH_HHI = 0.50            # HHI 集中度高线
+MAX_MARKET_WEIGHT = 0.70   # 单市场占比上限
+MIN_POSITIONS = 3          # 最少分散持仓数
+
+
+def herfindahl(values: list[float]) -> float:
+    """HHI 集中度 = Σ(w_i)²(w 为归一化权重)。范围 [1/n, 1],越大越集中。"""
+    total = sum(values)
+    if total <= 0:
+        return 0.0
+    return sum((v / total) ** 2 for v in values)
+
+
+def diagnose_positions(positions: list[dict]) -> dict:
+    """纯函数诊断。
+
+    positions: [{symbol, market, strategy_code, market_value, unrealized_pnl}]
+    """
+    if not positions:
+        return {
+            "position_count": 0,
+            "total_market_value": 0.0,
+            "hhi": 0.0,
+            "max_weight": 0.0,
+            "by_market": {},
+            "by_strategy": {},
+            "total_unrealized_pnl": 0.0,
+            "alerts": [],
+        }
+
+    values = [max(0.0, float(p.get("market_value") or 0.0)) for p in positions]
+    total = sum(values)
+    hhi = herfindahl(values)
+    max_w = (max(values) / total) if total > 0 else 0.0
+
+    by_market: dict[str, float] = {}
+    by_strategy: dict[str, float] = {}
+    for p, v in zip(positions, values):
+        m = p.get("market") or "?"
+        s = p.get("strategy_code") or "?"
+        by_market[m] = by_market.get(m, 0.0) + v
+        by_strategy[s] = by_strategy.get(s, 0.0) + v
+
+    upnl = sum(float(p.get("unrealized_pnl") or 0.0) for p in positions)
+
+    alerts: list[str] = []
+    if max_w >= MAX_SINGLE_WEIGHT:
+        alerts.append(f"单仓集中度过高:最大持仓占 {max_w * 100:.0f}%")
+    if hhi >= HIGH_HHI:
+        alerts.append(f"组合高度集中(HHI={hhi:.2f})")
+    if len(positions) < MIN_POSITIONS and total > 0:
+        alerts.append(f"持仓数过少({len(positions)}),分散不足")
+    if total > 0:
+        for m, v in by_market.items():
+            if v / total >= MAX_MARKET_WEIGHT:
+                alerts.append(f"{m} 市场占比过高({v / total * 100:.0f}%)")
+
+    return {
+        "position_count": len(positions),
+        "total_market_value": round(total, 2),
+        "hhi": round(hhi, 4),
+        "max_weight": round(max_w, 4),
+        "by_market": {k: round(v, 2) for k, v in by_market.items()},
+        "by_strategy": {k: round(v, 2) for k, v in by_strategy.items()},
+        "total_unrealized_pnl": round(upnl, 2),
+        "alerts": alerts,
+    }
+
+
+def diagnose_paper_portfolio() -> dict:
+    """读模拟盘 open 持仓 → 组合诊断(只读)。"""
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(PaperTradingPosition)
+            .filter(PaperTradingPosition.status == "open")
+            .all()
+        )
+        positions: list[dict] = []
+        for p in rows:
+            price = p.current_price or p.entry_price or 0.0
+            market_value = float(price) * int(p.quantity or 0)
+            positions.append(
+                {
+                    "symbol": p.stock_symbol,
+                    "market": p.stock_market,
+                    "strategy_code": p.strategy_code or "",
+                    "market_value": market_value,
+                    "unrealized_pnl": float(p.unrealized_pnl or 0.0),
+                }
+            )
+        return diagnose_positions(positions)
+    finally:
+        db.close()

--- a/src/core/quant_adapters.py
+++ b/src/core/quant_adapters.py
@@ -1,0 +1,49 @@
+"""量化框架适配器接口(Phase 4 预留,轻量)。
+
+定义统一的回测后端协议,让未来可插入不同实现而不改上层:
+- 内置(默认,永远可用):src/core/backtest(纯 Python 轻量内核,Phase 0)
+- 可选升级(按路线图,默认不安装,保持自托管轻量):
+    · vectorbt —— 向量化批量回测 / 因子网格寻参
+    · rqalpha  —— A 股高保真成本撮合(印花税/涨跌停/交易日历)
+    · qlib     —— ML 因子研究(Alpha158/360 + LightGBM 等)
+
+此处仅声明接口 + 探测「装了哪些后端」,真正接入时各写一个实现本协议的 adapter。
+选型依据见 .docs/quant-framework-comparison.md。
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BacktestAdapter(Protocol):
+    """回测后端统一接口。内置 backtest.engine.Backtester 已满足 run()。"""
+
+    name: str
+
+    def run(self, signals: list, bars_by_symbol: dict):  # noqa: D401
+        """对一批信号回测,返回带 metrics 的结果对象。"""
+        ...
+
+
+_OPTIONAL_BACKENDS = (
+    ("vectorbt", "vectorbt"),
+    ("rqalpha", "rqalpha"),
+    ("qlib", "qlib"),
+)
+
+
+def available_backends() -> dict[str, bool]:
+    """探测可用回测后端。内置永远可用;可选重依赖按是否已安装返回。
+
+    供 UI / 文档展示当前环境装了哪些后端,不触发任何安装。
+    """
+    backends: dict[str, bool] = {"builtin": True}
+    for module_name, key in _OPTIONAL_BACKENDS:
+        try:
+            __import__(module_name)
+            backends[key] = True
+        except Exception:
+            backends[key] = False
+    return backends

--- a/src/core/signal_explain.py
+++ b/src/core/signal_explain.py
@@ -1,0 +1,78 @@
+"""信号可解释化(Phase 3):rank_score → 1-10 AI Score + 正负因子拆解。
+
+对标 Danelfin 的 1-10 AI Score 与 green/red AI Factors:把 strategy_engine 已算出的
+score_breakdown(alpha/catalyst/quality/source_bonus 加分项,risk/crowd penalty 扣分项)
+拆成「正向(绿,提升)/ 负向(红,拖累)」两组,供机会页展示。
+
+纯函数,不依赖 DB;在 API 层对 list_strategy_signals 的结果做后处理注入。
+"""
+
+from __future__ import annotations
+
+# 因子中文标签
+FACTOR_LABELS = {
+    "alpha_score": "选股α",
+    "catalyst_score": "催化",
+    "quality_score": "计划质量",
+    "source_bonus": "来源加成",
+    "risk_penalty": "风险",
+    "crowd_penalty": "拥挤度",
+}
+
+# 加分类因子(正值=提升,负值=拖累)
+ADDITIVE_FACTORS = ("alpha_score", "catalyst_score", "quality_score", "source_bonus")
+# 惩罚类因子(正值=拖累,score_breakdown 中以正数表示惩罚强度)
+PENALTY_FACTORS = ("risk_penalty", "crowd_penalty")
+
+_EPS = 0.01
+
+
+def to_ai_score(rank_score) -> int:
+    """rank_score(0-100)→ 1-10 AI Score(clamp 到 [1,10])。"""
+    try:
+        s = float(rank_score or 0.0)
+    except (TypeError, ValueError):
+        s = 0.0
+    return max(1, min(10, round(s / 10.0)))
+
+
+def explain_factors(score_breakdown) -> dict:
+    """拆成正向(绿)/负向(红)两组,各按贡献绝对值排序取前 5。"""
+    sb = score_breakdown if isinstance(score_breakdown, dict) else {}
+    positive: list[dict] = []
+    negative: list[dict] = []
+
+    def _f(key):
+        try:
+            return float(sb.get(key))
+        except (TypeError, ValueError):
+            return None
+
+    for key in ADDITIVE_FACTORS:
+        v = _f(key)
+        if v is None:
+            continue
+        if v > _EPS:
+            positive.append({"factor": key, "label": FACTOR_LABELS.get(key, key), "contribution": round(v, 2)})
+        elif v < -_EPS:
+            negative.append({"factor": key, "label": FACTOR_LABELS.get(key, key), "contribution": round(v, 2)})
+
+    for key in PENALTY_FACTORS:
+        v = _f(key)
+        if v is None:
+            continue
+        if v > _EPS:  # 惩罚为正 = 拖累,贡献记为负
+            negative.append({"factor": key, "label": FACTOR_LABELS.get(key, key), "contribution": round(-v, 2)})
+
+    positive.sort(key=lambda x: x["contribution"], reverse=True)
+    negative.sort(key=lambda x: x["contribution"])  # 最负在前
+    return {"positive": positive[:5], "negative": negative[:5]}
+
+
+def enrich_signal(item: dict) -> dict:
+    """给一条信号 item 注入 ai_score + factor_explain(原地修改并返回)。"""
+    if not isinstance(item, dict):
+        return item
+    item["ai_score"] = to_ai_score(item.get("rank_score"))
+    item["factor_explain"] = explain_factors(item.get("score_breakdown"))
+    return item

--- a/src/web/api/paper_trading.py
+++ b/src/web/api/paper_trading.py
@@ -16,6 +16,8 @@ from src.core.paper_trading_engine import (
     market_allocations_or_default,
     normalize_allocations,
 )
+from src.core.portfolio_diagnostics import diagnose_paper_portfolio
+from src.core.quant_adapters import available_backends
 from src.web.database import get_db
 from src.web.models import (
     AppSettings,
@@ -412,6 +414,18 @@ def get_metrics(market: str | None = None, db: Session = Depends(get_db)):
         "open_positions": open_count,
         "strategy_performance": _strategy_performance(db, mkt),
     }
+
+
+@router.get("/diagnostics")
+def get_diagnostics():
+    """组合诊断(只读):集中度/市场与策略分布/风险提示。"""
+    return diagnose_paper_portfolio()
+
+
+@router.get("/backends")
+def get_backends():
+    """可用回测后端探测(builtin 永远可用;vectorbt/rqalpha/qlib 视安装情况)。"""
+    return available_backends()
 
 
 @router.post("/account/toggle")

--- a/src/web/api/recommendations.py
+++ b/src/web/api/recommendations.py
@@ -26,6 +26,7 @@ from src.core.strategy_engine import (
     rebalance_strategy_weights,
     refresh_strategy_signals,
 )
+from src.core.factor_eval import evaluate_factor_ic
 from src.web.database import SessionLocal
 from src.web.models import StrategySignalRun
 
@@ -357,6 +358,15 @@ def rebalance_strategy_weights_api(
 @router.get("/strategy-stats")
 def strategy_stats(days: int = Query(45, ge=1, le=365)):
     return get_strategy_stats(days=days)
+
+
+@router.get("/strategy-factor-ic")
+def strategy_factor_ic(
+    days: int = Query(90, ge=7, le=365, description="回看快照天数"),
+    horizon: int = Query(5, ge=1, le=60, description="持有期(交易日)"),
+):
+    """各因子的 IC/IR 有效性评估(StrategyFactorSnapshot × StrategyOutcome)。"""
+    return evaluate_factor_ic(days=days, horizon=horizon)
 
 
 @router.get("/strategy-weight-history")

--- a/src/web/api/recommendations.py
+++ b/src/web/api/recommendations.py
@@ -27,6 +27,7 @@ from src.core.strategy_engine import (
     refresh_strategy_signals,
 )
 from src.core.factor_eval import evaluate_factor_ic
+from src.core.signal_explain import enrich_signal
 from src.web.database import SessionLocal
 from src.web.models import StrategySignalRun
 
@@ -231,7 +232,7 @@ def get_strategy_signal_list(
     risk_level: str = Query("", description="风险等级: low/medium/high/all"),
     include_payload: bool = Query(False, description="是否返回完整 payload（默认否，提升性能）"),
 ):
-    return list_strategy_signals(
+    result = list_strategy_signals(
         market=market,
         status=status,
         min_score=min_score,
@@ -243,6 +244,10 @@ def get_strategy_signal_list(
         risk_level=risk_level,
         include_payload=include_payload,
     )
+    # Phase 3: 注入 1-10 可解释评分 + 正负因子拆解
+    for _it in result.get("items", []):
+        enrich_signal(_it)
+    return result
 
 
 @router.get("/strategy-regimes")

--- a/src/web/database.py
+++ b/src/web/database.py
@@ -134,6 +134,12 @@ def _backup_db_before_migration() -> None:
 def _migrate(engine):
     """增量 schema 迁移（SQLite ALTER TABLE ADD COLUMN）"""
     migrations = [
+        # Phase 1(模拟盘求真):持仓期最高价,移动止损用
+        (
+            "paper_trading_positions",
+            "highest_price",
+            "ALTER TABLE paper_trading_positions ADD COLUMN highest_price REAL",
+        ),
         (
             "stock_agents",
             "schedule",

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -961,6 +961,7 @@ class PaperTradingPosition(Base):
     stop_loss = Column(Float, nullable=True)
     target_price = Column(Float, nullable=True)
     current_price = Column(Float, nullable=True)
+    highest_price = Column(Float, nullable=True)  # 持仓期最高价(移动止损用)
     unrealized_pnl = Column(Float, nullable=False, default=0.0)
     status = Column(String, nullable=False, default="open")  # open/closed
     signal_run_id = Column(Integer, nullable=True)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,104 @@
+"""回测内核(Phase 0)单元测试 —— 纯合成数据,不触发网络。"""
+
+from src.core.backtest import metrics as M
+from src.core.backtest.cost_model import CostModel
+from src.core.backtest.data_adapter import PriceBar
+from src.core.backtest.engine import Backtester, Signal, horizon_return
+
+
+def _bar(date, o, h, low, c, v=1e6):
+    return PriceBar(date=date, open=o, high=h, low=low, close=c, volume=v)
+
+
+# ──────────────── 成本模型 ────────────────
+
+def test_cost_model_stamp_duty_sell_only():
+    """印花税仅卖出单边收取,买入不收。"""
+    cm = CostModel()
+    assert cm.fill("buy", 10.0, 1000).stamp_duty == 0.0
+    assert cm.fill("sell", 10.0, 1000).stamp_duty > 0.0
+
+
+def test_cost_model_min_commission():
+    """小额成交佣金不低于最低 5 元。"""
+    f = CostModel().fill("buy", 5.0, 100)  # gross≈500,万2.5≈0.125 → 取 5
+    assert f.commission == 5.0
+
+
+def test_round_trip_pnl_deducts_cost():
+    """同价买卖应净亏损(被成本与滑点吃掉)。"""
+    rt = CostModel().round_trip_pnl(10.0, 10.0, 1000)
+    assert rt["pnl"] < 0
+    assert rt["total_cost"] > 0
+
+
+# ──────────────── 绩效指标 ────────────────
+
+def test_metrics_max_drawdown():
+    """最大回撤 = 峰值到谷底的最大跌幅。"""
+    assert abs(M.max_drawdown([100, 120, 90, 110]) - (30 / 120)) < 1e-9
+
+
+def test_metrics_win_rate():
+    """胜率 = 正收益笔数 / 总笔数。"""
+    assert M.win_rate([1, -1, 2, -3]) == 0.5
+
+
+def test_metrics_profit_factor():
+    """盈亏比 = 总盈利 / 总亏损绝对值。"""
+    assert abs(M.profit_factor([3, -1, -1]) - 1.5) < 1e-9
+
+
+# ──────────────── 回测引擎 ────────────────
+
+def test_engine_entry_next_day():
+    """信号次日开盘入场,防止用当日数据(无未来函数)。"""
+    bars = [_bar("2026-01-01", 10, 10, 10, 10), _bar("2026-01-02", 11, 11, 11, 11),
+            _bar("2026-01-06", 11, 12.5, 11, 12)]
+    sig = Signal("X", "CN", "2026-01-01", stop_loss=9.0, target_price=12.0, holding_days=10)
+    t = Backtester().run_single(sig, bars)
+    assert t is not None and t.entry_date == "2026-01-02" and t.entry_price == 11
+
+
+def test_engine_stop_loss():
+    """价格跌破止损位按止损平仓。"""
+    bars = [_bar("2026-01-01", 10, 10, 10, 10), _bar("2026-01-02", 10, 10.2, 9.9, 10),
+            _bar("2026-01-05", 9.5, 9.6, 9.0, 9.2)]
+    sig = Signal("X", "CN", "2026-01-01", stop_loss=9.5, target_price=12.0, holding_days=10)
+    t = Backtester().run_single(sig, bars)
+    assert t.exit_reason == "stop_loss"
+
+
+def test_engine_target():
+    """价格触及止盈位按止盈平仓。"""
+    bars = [_bar("2026-01-01", 10, 10, 10, 10), _bar("2026-01-02", 10, 10, 10, 10),
+            _bar("2026-01-05", 11, 12.5, 11, 12)]
+    sig = Signal("X", "CN", "2026-01-01", stop_loss=9.0, target_price=12.0, holding_days=10)
+    t = Backtester().run_single(sig, bars)
+    assert t.exit_reason == "target"
+
+
+def test_engine_expire():
+    """达最大持有交易日按收盘平仓。"""
+    bars = [_bar(f"2026-01-{d:02d}", 10, 10.1, 9.9, 10) for d in range(1, 15)]
+    sig = Signal("X", "CN", "2026-01-01", stop_loss=5.0, target_price=20.0, holding_days=3)
+    t = Backtester().run_single(sig, bars)
+    assert t.exit_reason == "expire" and t.holding_bars == 3
+
+
+def test_horizon_return_matches_manual():
+    """horizon_return 复刻 StrategyOutcome 口径:(后收盘-基准)/基准。"""
+    bars = [_bar("2026-01-01", 10, 10, 10, 10), _bar("2026-01-02", 10, 11, 10, 11),
+            _bar("2026-01-06", 11, 12, 11, 12)]
+    sig = Signal("X", "CN", "2026-01-01", entry_price=10.0)
+    r = horizon_return(sig, bars, horizon_days=5)  # target_day=01-06 → outcome=12 → +20%
+    assert r is not None and abs(r - 20.0) < 1e-6
+
+
+def test_backtest_run_aggregates():
+    """批量回测聚合净值曲线与指标。"""
+    bars = [_bar(f"2026-01-{d:02d}", 10, 10.1, 9.9, 10) for d in range(1, 15)]
+    sigs = [Signal("X", "CN", "2026-01-01", stop_loss=5, target_price=20, holding_days=3)]
+    res = Backtester().run(sigs, {("X", "CN"): bars})
+    assert len(res.trades) == 1 and res.metrics["trades"] == 1
+    assert len(res.equity_curve) == 2

--- a/tests/test_factor_eval.py
+++ b/tests/test_factor_eval.py
@@ -1,0 +1,34 @@
+"""因子评估相关系数(Phase 2)单元测试 —— 纯函数,不触发 DB。"""
+
+from src.core.factor_eval import pearson, spearman
+
+
+def test_pearson_perfect_positive():
+    """完全正线性相关 = +1。"""
+    assert abs(pearson([1, 2, 3, 4, 5], [2, 4, 6, 8, 10]) - 1.0) < 1e-9
+
+
+def test_pearson_perfect_negative():
+    """完全负线性相关 = -1。"""
+    assert abs(pearson([1, 2, 3, 4, 5], [10, 8, 6, 4, 2]) + 1.0) < 1e-9
+
+
+def test_pearson_too_few_returns_none():
+    """样本不足 3 返回 None。"""
+    assert pearson([1, 2], [1, 2]) is None
+
+
+def test_pearson_zero_variance_none():
+    """零方差(常量序列)返回 None。"""
+    assert pearson([1, 1, 1, 1], [1, 2, 3, 4]) is None
+
+
+def test_spearman_monotonic_nonlinear():
+    """单调非线性关系下 Spearman = +1(秩相关)。"""
+    assert abs(spearman([1, 2, 3, 4, 5], [1, 4, 9, 16, 25]) - 1.0) < 1e-9
+
+
+def test_spearman_handles_ties():
+    """含并列值时仍返回合法相关系数(平均秩)。"""
+    r = spearman([1, 1, 2, 3], [1, 2, 2, 3])
+    assert r is not None and -1.0 <= r <= 1.0

--- a/tests/test_paper_trading_position.py
+++ b/tests/test_paper_trading_position.py
@@ -1,0 +1,56 @@
+"""模拟盘仓位管理(Phase 1)单元测试 —— 纯函数,不触发 DB/网络。"""
+
+from src.core.backtest.cost_model import CostModel
+from src.core.paper_trading_engine import _compute_quantity, _position_weight
+
+
+def test_position_weight_tiers():
+    """信号强度越高,单笔资金占比越大(分档)。"""
+    assert _position_weight(90) == 0.25
+    assert _position_weight(80) == 0.18
+    assert _position_weight(70) == 0.12
+    assert _position_weight(50) == 0.08
+    assert _position_weight(90) > _position_weight(50)
+
+
+def test_compute_quantity_respects_budget():
+    """按市场预算 × 强度比例分配,买入 100 股整数倍且不超预算对应股数。"""
+    cm = CostModel()
+    qty = _compute_quantity(
+        rank_score=90, market_budget=1_000_000, price=10.0,
+        available_cash=1_000_000, cost_model=cm,
+    )
+    assert qty > 0 and qty % 100 == 0
+    assert qty <= 25000  # 25% 预算 / 10 元
+
+
+def test_compute_quantity_respects_cash():
+    """可用现金不足时回退到买得起的手数,买入含费不超现金。"""
+    cm = CostModel()
+    qty = _compute_quantity(
+        rank_score=90, market_budget=1_000_000, price=10.0,
+        available_cash=3000, cost_model=cm,
+    )
+    assert qty % 100 == 0
+    if qty > 0:
+        outlay = -cm.fill("buy", 10.0, qty).cash_delta
+        assert outlay <= 3000
+
+
+def test_compute_quantity_insufficient_cash_returns_zero():
+    """现金连最小一手都买不起时返回 0(应跳过建仓)。"""
+    cm = CostModel()
+    qty = _compute_quantity(
+        rank_score=90, market_budget=1_000_000, price=100.0,
+        available_cash=500, cost_model=cm,
+    )
+    assert qty == 0
+
+
+def test_engine_imports_ok():
+    """改造后 paper_trading_engine 可正常导入(无语法/循环 import 错),关键符号在位。"""
+    import src.core.paper_trading_engine as e
+
+    assert hasattr(e, "ENGINE")
+    assert hasattr(e, "COST_MODEL")
+    assert hasattr(e, "_compute_quantity")

--- a/tests/test_portfolio_diagnostics.py
+++ b/tests/test_portfolio_diagnostics.py
@@ -1,0 +1,49 @@
+"""组合诊断(Phase 4)单元测试 —— 纯函数,不触发 DB。"""
+
+from src.core.portfolio_diagnostics import diagnose_positions, herfindahl
+
+
+def test_herfindahl_fully_concentrated():
+    """全压一只 → HHI = 1。"""
+    assert abs(herfindahl([100, 0, 0, 0]) - 1.0) < 1e-9
+
+
+def test_herfindahl_evenly_diversified():
+    """四只等权 → HHI = 0.25。"""
+    assert abs(herfindahl([25, 25, 25, 25]) - 0.25) < 1e-9
+
+
+def test_diagnose_empty():
+    """空持仓不报错,计数为 0。"""
+    assert diagnose_positions([])["position_count"] == 0
+
+
+def test_diagnose_max_weight_alert():
+    """最大单仓超 40% 触发集中度告警。"""
+    pos = [
+        {"market_value": 600, "market": "CN", "strategy_code": "a"},
+        {"market_value": 400, "market": "CN", "strategy_code": "b"},
+    ]
+    r = diagnose_positions(pos)
+    assert r["max_weight"] == 0.6
+    assert any("集中度" in a for a in r["alerts"])
+
+
+def test_diagnose_by_market_distribution():
+    """按市场聚合市值正确。"""
+    pos = [
+        {"market_value": 500, "market": "CN"},
+        {"market_value": 500, "market": "US"},
+    ]
+    r = diagnose_positions(pos)
+    assert r["by_market"]["CN"] == 500 and r["by_market"]["US"] == 500
+    assert r["total_market_value"] == 1000
+
+
+def test_diagnose_unrealized_pnl_sum():
+    """浮动盈亏汇总正确。"""
+    pos = [
+        {"market_value": 100, "unrealized_pnl": 12.5},
+        {"market_value": 100, "unrealized_pnl": -4.0},
+    ]
+    assert diagnose_positions(pos)["total_unrealized_pnl"] == 8.5

--- a/tests/test_signal_explain.py
+++ b/tests/test_signal_explain.py
@@ -1,0 +1,45 @@
+"""信号可解释化(Phase 3)单元测试 —— 纯函数。"""
+
+from src.core.signal_explain import enrich_signal, explain_factors, to_ai_score
+
+
+def test_ai_score_mapping():
+    """rank_score 0-100 映射到 1-10 并 clamp。"""
+    assert to_ai_score(0) == 1
+    assert to_ai_score(50) == 5
+    assert to_ai_score(100) == 10
+    assert to_ai_score(30) == 3
+    assert to_ai_score(None) == 1  # 兜底
+
+
+def test_explain_factors_splits_positive_negative():
+    """加分因子正值入绿、负值入红;惩罚因子入红。"""
+    sb = {"alpha_score": 5.0, "catalyst_score": -2.0, "quality_score": 3.0,
+          "risk_penalty": 3.0, "crowd_penalty": 0.0}
+    r = explain_factors(sb)
+    pos = {x["factor"] for x in r["positive"]}
+    neg = {x["factor"] for x in r["negative"]}
+    assert "alpha_score" in pos and "quality_score" in pos
+    assert "catalyst_score" in neg   # 加分因子取负值 → 拖累
+    assert "risk_penalty" in neg     # 惩罚为正 → 拖累
+    assert "crowd_penalty" not in neg  # 为 0 不计
+
+
+def test_explain_factors_penalty_contribution_negative():
+    """惩罚因子的 contribution 记为负数(表示拖累)。"""
+    r = explain_factors({"risk_penalty": 4.0})
+    item = next(x for x in r["negative"] if x["factor"] == "risk_penalty")
+    assert item["contribution"] == -4.0
+
+
+def test_enrich_signal_adds_fields():
+    """enrich_signal 注入 ai_score 与 factor_explain。"""
+    out = enrich_signal({"rank_score": 80, "score_breakdown": {"alpha_score": 5.0}})
+    assert out["ai_score"] == 8
+    assert "positive" in out["factor_explain"]
+
+
+def test_explain_factors_empty():
+    """空 breakdown 返回空两组,不报错。"""
+    r = explain_factors(None)
+    assert r == {"positive": [], "negative": []}


### PR DESCRIPTION
## 背景

重规划的 M1:把 2 周前「已写未并」的 `feat/paper-trading-roadmap`(Phase 0–4)合并到含「行情整治 + 加仓评估」的最新 main。这条分支覆盖了既有调研里第一梯队的功能缺口。

## 内容(自动合并,零冲突)

- **Phase 0 回测地基** — `src/core/backtest/`(cost_model / data_adapter / engine / metrics):事件式回测 + A股成本模型
- **Phase 1 模拟盘求真** — `paper_trading_engine`:交易成本(印花税/佣金/滑点)+ 仓位管理 + 移动/时间止损(替换 `FIXED_QUANTITY=100` 失真模型)
- **Phase 2 因子 IC/IR** — `quant_adapters`:信号验证
- **Phase 3 机会页 2.0** — `signal_explain` + `Opportunities.tsx`:可解释 AI 评分 + 正负(红绿)因子
- **Phase 4 组合诊断** — `portfolio_diagnostics`:集中度/暴露/相关/回撤

对标:回测 ≈ Vibe-Trading/DSA;评分 ≈ Danelfin;组合诊断 ≈ PortfolioPilot。

## 关键:两边工作共存

近期已合并的「行情采集整治(market_http / K线缓存 / discovery 直连 / 来源标记)」与「加仓成本测算 + AI 评估」**全部保留**,未被旧分支回退。

## 验收

- 后端 `pytest tests/` → **322 passed, 1 skipped**(含分支 5 个新测试:test_backtest / test_factor_eval / test_portfolio_diagnostics / test_signal_explain / test_paper_trading_position)
- 前端 `tsc -b` → 通过
- pre-push hook 已跑通

规划详见 `.docs/product-replan-2026-06-18.md`。