### PR TITLE
fix(kline): 同标的并发取数合并 + 失败负缓存 — 根除收盘后 K线限流日志风暴

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **自托管 AI 盯盘助手 · 集成 [TradingAgents](https://github.com/TauricResearch/TradingAgents) 多 Agent 投资决策** — A 股 / 港股 / 美股实时监控、持仓管理、智能分析、全渠道推送
 
 [![GitHub stars](https://img.shields.io/github/stars/TNT-Likely/PanWatch?style=flat&logo=github&color=yellow)](https://github.com/TNT-Likely/PanWatch/stargazers)
-[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker)](https://hub.docker.com/r/sunxiao0721/panwatch)
+[![Docker Pulls](https://img.shields.io/docker/pulls/sunxiao0721/panwatch?logo=docker&label=docker%20pulls&color=2496ED)](https://hub.docker.com/r/sunxiao0721/panwatch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/TNT-Likely/PanWatch)](https://github.com/TNT-Likely/PanWatch/commits/main)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -162,24 +162,22 @@ function App() {
               })}
             </nav>
 
-            {/* 外侧:GitHub + 日志;头像下拉:更多导航 + 主题色 + 退出登录 */}
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
-                <button
-                  onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
-                  className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                  title="GitHub 项目"
-                >
-                  <Github className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={() => setLogsOpen(true)}
-                  className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                  title="查看日志"
-                >
-                  <ScrollText className="w-4 h-4" />
-                </button>
-              </div>
+            {/* action wrapper:GitHub + 日志 + 头像(头像下拉含更多导航/主题色/退出) */}
+            <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
+              <button
+                onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
+                className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                title="GitHub 项目"
+              >
+                <Github className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setLogsOpen(true)}
+                className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                title="查看日志"
+              >
+                <ScrollText className="w-4 h-4" />
+              </button>
               <AccountMenu
                 navItems={desktopMoreNavItems}
                 mode={mode}
@@ -201,23 +199,21 @@ function App() {
               <span className="text-[14px] font-bold text-foreground">PanWatch</span>
               {version && <span className="text-[10px] text-muted-foreground/60 font-normal">v{version}</span>}
             </NavLink>
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
-                <button
-                  onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
-                  className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                  title="GitHub 项目"
-                >
-                  <Github className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={() => setLogsOpen(true)}
-                  className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                  title="查看日志"
-                >
-                  <ScrollText className="w-4 h-4" />
-                </button>
-              </div>
+            <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
+              <button
+                onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
+                className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                title="GitHub 项目"
+              >
+                <Github className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setLogsOpen(true)}
+                className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                title="查看日志"
+              >
+                <ScrollText className="w-4 h-4" />
+              </button>
               <AccountMenu
                 size="sm"
                 navItems={mobileMoreNavItems}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { Routes, Route, NavLink, useLocation, Navigate } from 'react-router-dom'
-import { Moon, Sun, TrendingUp, Bot, ScrollText, Settings, List, Database, Clock, LayoutDashboard, LogOut, Github, BellRing, MoreHorizontal, Sparkles, Activity } from 'lucide-react'
+import { TrendingUp, Bot, ScrollText, Settings, List, Database, Clock, LayoutDashboard, Github, BellRing, Sparkles, Activity } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
-import { appApi, fetchAPI, isAuthenticated, logout } from '@panwatch/api'
+import { appApi, fetchAPI, isAuthenticated } from '@panwatch/api'
 import DashboardPage from '@/pages/Dashboard'
 import OpportunitiesPage from '@/pages/Opportunities'
 import StocksPage from '@/pages/Stocks'
@@ -17,6 +17,7 @@ import LoginPage from '@/pages/Login'
 import LogsModal from '@panwatch/biz-ui/components/logs-modal'
 import AmbientBackground from '@panwatch/biz-ui/components/AmbientBackground'
 import ChatWidget from '@/components/ChatWidget'
+import AccountMenu from '@/components/AccountMenu'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@panwatch/base-ui/components/ui/dialog'
 import { Button } from '@panwatch/base-ui/components/ui/button'
 
@@ -68,17 +69,13 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
-  const { theme, toggleTheme } = useTheme()
+  const { mode, setMode } = useTheme()
   const location = useLocation()
   const [version, setVersion] = useState('')
   const [logsOpen, setLogsOpen] = useState(false)
   const [upgradeOpen, setUpgradeOpen] = useState(false)
   const [upgradeInfo, setUpgradeInfo] = useState<{ latest: string; url: string } | null>(null)
-  const [desktopMoreOpen, setDesktopMoreOpen] = useState(false)
-  const [mobileMoreOpen, setMobileMoreOpen] = useState(false)
   const checkedUpdateRef = useRef(false)
-  const desktopMoreRef = useRef<HTMLDivElement | null>(null)
-  const mobileMoreRef = useRef<HTMLDivElement | null>(null)
   const repoUrl = 'https://github.com/TNT-Likely/PanWatch'
 
   useEffect(() => {
@@ -106,25 +103,6 @@ function App() {
       })
       .catch(() => {})
   }, [version])
-
-  useEffect(() => {
-    const onDocPointerDown = (e: PointerEvent) => {
-      const t = e.target as Node
-      if (desktopMoreOpen && desktopMoreRef.current && !desktopMoreRef.current.contains(t)) {
-        setDesktopMoreOpen(false)
-      }
-      if (mobileMoreOpen && mobileMoreRef.current && !mobileMoreRef.current.contains(t)) {
-        setMobileMoreOpen(false)
-      }
-    }
-    document.addEventListener('pointerdown', onDocPointerDown)
-    return () => document.removeEventListener('pointerdown', onDocPointerDown)
-  }, [desktopMoreOpen, mobileMoreOpen])
-
-  useEffect(() => {
-    setDesktopMoreOpen(false)
-    setMobileMoreOpen(false)
-  }, [location.pathname])
 
   // 登录页面不显示导航
   if (location.pathname === '/login') {
@@ -182,73 +160,31 @@ function App() {
                   </NavLink>
                 )
               })}
-              <div className="relative" ref={desktopMoreRef}>
-                <button
-                  onClick={() => setDesktopMoreOpen(v => !v)}
-                  className={`relative px-3.5 py-2 rounded-xl text-[13px] font-medium transition-all flex items-center gap-1.5 ${
-                    desktopMoreNavItems.some(item => location.pathname.startsWith(item.to))
-                      ? 'text-foreground bg-[linear-gradient(135deg,hsl(var(--primary)/0.14),hsl(var(--primary)/0.04),hsl(var(--success)/0.06))] ring-1 ring-primary/20 shadow-[0_8px_24px_-18px_hsl(var(--primary)/0.55)]'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                  }`}
-                >
-                  <MoreHorizontal className="w-4 h-4" />
-                  更多
-                </button>
-                {desktopMoreOpen && (
-                  <div className="absolute right-0 mt-2 w-40 rounded-xl border border-border/60 bg-card/95 backdrop-blur p-1.5 shadow-xl">
-                    {desktopMoreNavItems.map(({ to, icon: Icon, label }) => {
-                      const isActive = location.pathname.startsWith(to)
-                      return (
-                        <NavLink
-                          key={to}
-                          to={to}
-                          onClick={() => setDesktopMoreOpen(false)}
-                          className={`flex items-center gap-2 px-2.5 py-2 rounded-lg text-[12px] transition-colors ${
-                            isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
-                          }`}
-                        >
-                          <Icon className="w-3.5 h-3.5" />
-                          {label}
-                        </NavLink>
-                      )
-                    })}
-                  </div>
-                )}
-              </div>
             </nav>
 
-            {/* Theme Toggle & Logout */}
-            <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
-              <button
-                onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
-                className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title="GitHub 项目"
-              >
-                <Github className="w-4 h-4" />
-              </button>
-              <button
-                onClick={() => setLogsOpen(true)}
-                className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title="查看日志"
-              >
-                <ScrollText className="w-4 h-4" />
-              </button>
-              <button
-                onClick={toggleTheme}
-                className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title={theme === 'dark' ? '切换到亮色' : '切换到暗色'}
-              >
-                {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-              </button>
-              {isAuthenticated() && (
+            {/* 外侧:GitHub + 日志;头像下拉:更多导航 + 主题色 + 退出登录 */}
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
                 <button
-                  onClick={logout}
-                  className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
-                  title="退出登录"
+                  onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
+                  className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                  title="GitHub 项目"
                 >
-                  <LogOut className="w-4 h-4" />
+                  <Github className="w-4 h-4" />
                 </button>
-              )}
+                <button
+                  onClick={() => setLogsOpen(true)}
+                  className="w-9 h-9 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                  title="查看日志"
+                >
+                  <ScrollText className="w-4 h-4" />
+                </button>
+              </div>
+              <AccountMenu
+                navItems={desktopMoreNavItems}
+                mode={mode}
+                onSetMode={setMode}
+              />
             </div>
           </div>
         </header>
@@ -265,35 +201,36 @@ function App() {
               <span className="text-[14px] font-bold text-foreground">PanWatch</span>
               {version && <span className="text-[10px] text-muted-foreground/60 font-normal">v{version}</span>}
             </NavLink>
-            <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
-              <button
-                onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
-                className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title="GitHub 项目"
-              >
-                <Github className="w-4 h-4" />
-              </button>
-              <button
-                onClick={() => setLogsOpen(true)}
-                className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title="查看日志"
-              >
-                <ScrollText className="w-4 h-4" />
-              </button>
-              <button
-                onClick={toggleTheme}
-                className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
-                title={theme === 'dark' ? '切换到亮色' : '切换到暗色'}
-              >
-                {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-              </button>
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1.5 px-1.5 py-1 rounded-2xl bg-accent/20 border border-border/40">
+                <button
+                  onClick={() => window.open(repoUrl, '_blank', 'noopener,noreferrer')}
+                  className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                  title="GitHub 项目"
+                >
+                  <Github className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => setLogsOpen(true)}
+                  className="w-8 h-8 rounded-xl flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-background/70 transition-all"
+                  title="查看日志"
+                >
+                  <ScrollText className="w-4 h-4" />
+                </button>
+              </div>
+              <AccountMenu
+                size="sm"
+                navItems={mobileMoreNavItems}
+                mode={mode}
+                onSetMode={setMode}
+              />
             </div>
           </div>
         </header>
       </div>
 
       {/* Mobile Bottom Nav */}
-      <nav className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-card border-t border-border px-2 pb-[env(safe-area-inset-bottom)]" ref={mobileMoreRef}>
+      <nav className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-card border-t border-border px-2 pb-[env(safe-area-inset-bottom)]">
         <div className="flex items-center justify-around h-14">
           {mobilePrimaryNavItems.map(({ to, icon: Icon, label }) => {
             const isActive = to === '/' ? location.pathname === '/' : location.pathname.startsWith(to)
@@ -312,38 +249,7 @@ function App() {
               </NavLink>
             )
           })}
-          <button
-            onClick={() => setMobileMoreOpen(v => !v)}
-            className={`flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 rounded-xl transition-all min-w-[56px] ${
-              mobileMoreNavItems.some(item => location.pathname.startsWith(item.to))
-                ? 'text-primary bg-primary/8 ring-1 ring-primary/15'
-                : 'text-muted-foreground hover:bg-accent/30'
-            }`}
-          >
-            <MoreHorizontal className="w-5 h-5" />
-            <span className="text-[10px] font-medium">更多</span>
-          </button>
         </div>
-        {mobileMoreOpen && (
-          <div className="absolute bottom-[58px] right-2 w-40 rounded-xl border border-border/60 bg-card/95 backdrop-blur p-1.5 shadow-xl">
-            {mobileMoreNavItems.map(({ to, icon: Icon, label }) => {
-              const isActive = location.pathname.startsWith(to)
-              return (
-                <NavLink
-                  key={to}
-                  to={to}
-                  onClick={() => setMobileMoreOpen(false)}
-                  className={`flex items-center gap-2 px-2.5 py-2 rounded-lg text-[12px] transition-colors ${
-                    isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
-                  }`}
-                >
-                  <Icon className="w-3.5 h-3.5" />
-                  {label}
-                </NavLink>
-              )
-            })}
-          </div>
-        )}
       </nav>
 
       {/* Content */}

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useRef } from 'react'
+import { NavLink, useLocation } from 'react-router-dom'
+import { Moon, Sun, Monitor, Check, LogOut, User, type LucideIcon } from 'lucide-react'
+import { isAuthenticated, logout } from '@panwatch/api'
+import type { ThemeMode } from '@/hooks/use-theme'
+
+export interface AccountNavItem {
+  to: string
+  icon: LucideIcon
+  label: string
+}
+
+const THEME_OPTIONS: { value: ThemeMode; icon: LucideIcon; label: string }[] = [
+  { value: 'light', icon: Sun, label: '亮色' },
+  { value: 'dark', icon: Moon, label: '暗色' },
+  { value: 'system', icon: Monitor, label: '跟随系统' },
+]
+
+interface AccountMenuProps {
+  /** 原“更多”里折叠的导航项(Agent / 历史 / 数据源 / 设置)。 */
+  navItems: AccountNavItem[]
+  mode: ThemeMode
+  onSetMode: (m: ThemeMode) => void
+  /** 头像尺寸:桌面 md,移动端 sm。 */
+  size?: 'sm' | 'md'
+}
+
+/**
+ * 右上角头像区域 + 下拉菜单(参考 beecount-cloud):
+ * 把原“更多”导航、主题色(亮/暗/跟随系统)、退出登录收进头像下拉
+ * (查看日志 / GitHub 仍在外侧)。
+ */
+export default function AccountMenu({
+  navItems,
+  mode,
+  onSetMode,
+  size = 'md',
+}: AccountMenuProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const location = useLocation()
+
+  // 点击外部关闭
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  // 路由变化时关闭
+  useEffect(() => {
+    setOpen(false)
+  }, [location.pathname])
+
+  const avatarSize = size === 'sm' ? 'w-8 h-8' : 'w-9 h-9'
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        className={`${avatarSize} rounded-full bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-sm ring-1 transition-all ${
+          open ? 'ring-primary/50' : 'ring-border/40 hover:ring-primary/40'
+        }`}
+        title="账户与设置"
+        aria-label="账户与设置"
+      >
+        <User className="w-4 h-4 text-white" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-48 rounded-xl border border-border/60 bg-card/95 backdrop-blur p-1.5 shadow-xl z-50">
+          {/* 原“更多”导航 */}
+          {navItems.map(({ to, icon: Icon, label }) => {
+            const isActive = location.pathname.startsWith(to)
+            return (
+              <NavLink
+                key={to}
+                to={to}
+                onClick={() => setOpen(false)}
+                className={`flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-[12px] transition-colors ${
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+              </NavLink>
+            )
+          })}
+
+          <div className="my-1 h-px bg-border/50" />
+
+          {/* 主题色:亮 / 暗 / 跟随系统 */}
+          <div className="px-2.5 pt-0.5 pb-1 text-[11px] text-muted-foreground">主题</div>
+          {THEME_OPTIONS.map(({ value, icon: Icon, label }) => {
+            const active = mode === value
+            return (
+              <button
+                key={value}
+                onClick={() => onSetMode(value)}
+                className={`flex w-full items-center gap-2.5 px-2.5 py-2 rounded-lg text-[12px] transition-colors ${
+                  active
+                    ? 'text-foreground bg-accent/40'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+                {active && <Check className="w-3.5 h-3.5 ml-auto text-primary" />}
+              </button>
+            )
+          })}
+
+          {isAuthenticated() && (
+            <>
+              <div className="my-1 h-px bg-border/50" />
+              <button
+                onClick={logout}
+                className="flex w-full items-center gap-2.5 px-2.5 py-2 rounded-lg text-[12px] text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+              >
+                <LogOut className="w-3.5 h-3.5" />
+                退出登录
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom'
 import { Moon, Sun, Monitor, Check, LogOut, User, type LucideIcon } from 'lucide-react'
 import { isAuthenticated, logout } from '@panwatch/api'
 import type { ThemeMode } from '@/hooks/use-theme'
+import { useAvatar } from '@/hooks/use-avatar'
 
 export interface AccountNavItem {
   to: string
@@ -39,6 +40,11 @@ export default function AccountMenu({
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement | null>(null)
   const location = useLocation()
+  const avatar = useAvatar()
+  // 仅在支持 hover 的设备(PC)启用悬停展开;触屏维持点击
+  const [canHover] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches,
+  )
 
   // 点击外部关闭
   useEffect(() => {
@@ -56,23 +62,35 @@ export default function AccountMenu({
     setOpen(false)
   }, [location.pathname])
 
-  const avatarSize = size === 'sm' ? 'w-8 h-8' : 'w-9 h-9'
+  const avatarSize = size === 'sm' ? 'w-6 h-6' : 'w-7 h-7'
+  const iconSize = size === 'sm' ? 'w-3.5 h-3.5' : 'w-4 h-4'
 
   return (
-    <div className="relative" ref={ref}>
+    <div
+      className="relative"
+      ref={ref}
+      onMouseEnter={canHover ? () => setOpen(true) : undefined}
+      onMouseLeave={canHover ? () => setOpen(false) : undefined}
+    >
       <button
         onClick={() => setOpen(v => !v)}
-        className={`${avatarSize} rounded-full bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-sm ring-1 transition-all ${
+        className={`${avatarSize} rounded-full overflow-hidden bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-sm ring-1 transition-all ${
           open ? 'ring-primary/50' : 'ring-border/40 hover:ring-primary/40'
         }`}
         title="账户与设置"
         aria-label="账户与设置"
       >
-        <User className="w-4 h-4 text-white" />
+        {avatar ? (
+          <img src={avatar} alt="头像" className="w-full h-full object-cover" />
+        ) : (
+          <User className={`${iconSize} text-white`} />
+        )}
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-48 rounded-xl border border-border/60 bg-card/95 backdrop-blur p-1.5 shadow-xl z-50">
+        // top-full + pt-2:用透明内边距桥接头像与菜单,hover 移入不断开
+        <div className="absolute right-0 top-full pt-2 z-50">
+          <div className="w-48 rounded-xl border border-border/60 bg-card/95 backdrop-blur p-1.5 shadow-xl">
           {/* 原“更多”导航 */}
           {navItems.map(({ to, icon: Icon, label }) => {
             const isActive = location.pathname.startsWith(to)
@@ -128,6 +146,7 @@ export default function AccountMenu({
               </button>
             </>
           )}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/hooks/use-avatar.ts
+++ b/frontend/src/hooks/use-avatar.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect } from 'react'
+import { fetchAPI } from '@panwatch/api'
+
+const EVENT = 'panwatch:avatar-changed'
+let cache: string | null = null
+let inflight: Promise<string> | null = null
+
+function load(): Promise<string> {
+  if (cache !== null) return Promise.resolve(cache)
+  if (!inflight) {
+    inflight = fetchAPI<{ value: string }>('/settings/avatar')
+      .then(r => {
+        cache = r?.value || ''
+        return cache
+      })
+      .catch(() => {
+        cache = ''
+        return ''
+      })
+  }
+  return inflight
+}
+
+/** 保存头像(传空字符串清空)并广播,使所有头像处即时更新。 */
+export async function saveAvatar(value: string): Promise<void> {
+  await fetchAPI('/settings/avatar', { method: 'PUT', body: JSON.stringify({ value }) })
+  cache = value
+  window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: value }))
+}
+
+/** 当前头像(data URL 或图片地址),未设置为空串。跨组件即时同步。 */
+export function useAvatar(): string {
+  const [avatar, setAvatar] = useState<string>(cache ?? '')
+  useEffect(() => {
+    let alive = true
+    load().then(v => {
+      if (alive) setAvatar(v)
+    })
+    const onChange = (e: Event) => setAvatar((e as CustomEvent<string>).detail ?? '')
+    window.addEventListener(EVENT, onChange)
+    return () => {
+      alive = false
+      window.removeEventListener(EVENT, onChange)
+    }
+  }, [])
+  return avatar
+}
+
+/**
+ * 把上传的图片文件压缩为 128×128 的方形 JPEG data URL(居中裁剪),
+ * 控制体积(约 10-20KB),避免大 base64 撑爆设置存储。
+ */
+export function fileToAvatarDataUrl(file: File, size = 128): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(new Error('读取文件失败'))
+    reader.onload = () => {
+      const img = new Image()
+      img.onerror = () => reject(new Error('图片解析失败'))
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext('2d')
+        if (!ctx) {
+          reject(new Error('canvas 不可用'))
+          return
+        }
+        // 居中裁剪填满方形
+        const scale = Math.max(size / img.width, size / img.height)
+        const w = img.width * scale
+        const h = img.height * scale
+        ctx.drawImage(img, (size - w) / 2, (size - h) / 2, w, h)
+        resolve(canvas.toDataURL('image/jpeg', 0.85))
+      }
+      img.src = reader.result as string
+    }
+    reader.readAsDataURL(file)
+  })
+}

--- a/frontend/src/hooks/use-avatar.ts
+++ b/frontend/src/hooks/use-avatar.ts
@@ -21,9 +21,13 @@ function load(): Promise<string> {
   return inflight
 }
 
-/** 保存头像(传空字符串清空)并广播,使所有头像处即时更新。 */
+/**
+ * 保存头像(传空字符串清空)并广播,使所有头像处即时更新。
+ * 走通用 PUT /settings/{key}(catch-all)写入 ui_avatar:不依赖新路由注册顺序,
+ * 读取则用 GET /settings/avatar(单独读 ui_avatar)。
+ */
 export async function saveAvatar(value: string): Promise<void> {
-  await fetchAPI('/settings/avatar', { method: 'PUT', body: JSON.stringify({ value }) })
+  await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
   cache = value
   window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: value }))
 }

--- a/frontend/src/hooks/use-avatar.ts
+++ b/frontend/src/hooks/use-avatar.ts
@@ -2,44 +2,66 @@ import { useState, useEffect } from 'react'
 import { fetchAPI } from '@panwatch/api'
 
 const EVENT = 'panwatch:avatar-changed'
-let cache: string | null = null
-let inflight: Promise<string> | null = null
+const LS_KEY = 'panwatch-avatar'
 
-function load(): Promise<string> {
-  if (cache !== null) return Promise.resolve(cache)
-  if (!inflight) {
-    inflight = fetchAPI<{ value: string }>('/settings/avatar')
-      .then(r => {
-        cache = r?.value || ''
-        return cache
-      })
-      .catch(() => {
-        cache = ''
-        return ''
-      })
+function readLocal(): string {
+  try {
+    return localStorage.getItem(LS_KEY) || ''
+  } catch {
+    return ''
   }
-  return inflight
 }
 
 /**
- * 保存头像(传空字符串清空)并广播,使所有头像处即时更新。
- * 走通用 PUT /settings/{key}(catch-all)写入 ui_avatar:不依赖新路由注册顺序,
- * 读取则用 GET /settings/avatar(单独读 ui_avatar)。
+ * 保存头像(传空字符串=清空):
+ * 1) 先写 localStorage 并广播 —— 立即生效,刷新不丢,不依赖后端新路由是否已部署;
+ * 2) 后台同步到后端(多设备/换浏览器),失败不影响本地显示。
  */
 export async function saveAvatar(value: string): Promise<void> {
-  await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
-  cache = value
+  try {
+    if (value) localStorage.setItem(LS_KEY, value)
+    else localStorage.removeItem(LS_KEY)
+  } catch {
+    /* 忽略 localStorage 配额错误 */
+  }
   window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: value }))
+  try {
+    await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
+  } catch {
+    /* 后端同步失败不阻塞本地 */
+  }
 }
 
-/** 当前头像(data URL 或图片地址),未设置为空串。跨组件即时同步。 */
+let calibrated = false
+
+/**
+ * 当前头像(data URL 或图片地址)。localStorage 优先(刷新即在),
+ * 首次再用后端 GET /settings/avatar 校准(多设备同步;旧后端无该路由时忽略错误,保留本地)。
+ */
 export function useAvatar(): string {
-  const [avatar, setAvatar] = useState<string>(cache ?? '')
+  const [avatar, setAvatar] = useState<string>(readLocal)
+
   useEffect(() => {
     let alive = true
-    load().then(v => {
-      if (alive) setAvatar(v)
-    })
+    if (!calibrated) {
+      calibrated = true
+      fetchAPI<{ value: string }>('/settings/avatar')
+        .then(r => {
+          const v = r?.value || ''
+          if (!alive || v === readLocal()) return
+          // 后端可达即视为权威:有值则采用,空值则清本地;两边都写
+          try {
+            if (v) localStorage.setItem(LS_KEY, v)
+            else localStorage.removeItem(LS_KEY)
+          } catch {
+            /* ignore */
+          }
+          window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: v }))
+        })
+        .catch(() => {
+          /* 后端旧版无 /settings/avatar 路由或网络错误:保留本地值 */
+        })
+    }
     const onChange = (e: Event) => setAvatar((e as CustomEvent<string>).detail ?? '')
     window.addEventListener(EVENT, onChange)
     return () => {
@@ -47,12 +69,13 @@ export function useAvatar(): string {
       window.removeEventListener(EVENT, onChange)
     }
   }, [])
+
   return avatar
 }
 
 /**
- * 把上传的图片文件压缩为 128×128 的方形 JPEG data URL(居中裁剪),
- * 控制体积(约 10-20KB),避免大 base64 撑爆设置存储。
+ * 把上传的图片文件压缩为 size×size 的方形 JPEG data URL(居中裁剪),
+ * 控制体积(约 10-20KB),避免大 base64 撑爆存储。
  */
 export function fileToAvatarDataUrl(file: File, size = 128): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -70,7 +93,6 @@ export function fileToAvatarDataUrl(file: File, size = 128): Promise<string> {
           reject(new Error('canvas 不可用'))
           return
         }
-        // 居中裁剪填满方形
         const scale = Math.max(size / img.width, size / img.height)
         const w = img.width * scale
         const h = img.height * scale

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -1,22 +1,44 @@
 import { useState, useEffect } from 'react'
 
-type Theme = 'light' | 'dark'
+/** 用户选择的主题模式(system = 跟随系统)。 */
+export type ThemeMode = 'light' | 'dark' | 'system'
+/** 实际生效的主题(system 解析后的结果)。 */
+export type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'panwatch-theme'
+
+function readMode(): ThemeMode {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  return 'system'
+}
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const stored = localStorage.getItem('panwatch-theme') as Theme
-    if (stored) return stored
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-  })
+  const [mode, setMode] = useState<ThemeMode>(readMode)
+  const [systemDark, setSystemDark] = useState(
+    () => window.matchMedia('(prefers-color-scheme: dark)').matches,
+  )
+
+  // 跟随系统:监听 OS 主题变化,实时反映
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = (e: MediaQueryListEvent) => setSystemDark(e.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  // 生效主题:显式 light/dark 直接用,system 则跟随当前系统
+  const theme: Theme = mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
 
   useEffect(() => {
     const root = document.documentElement
     root.classList.remove('light', 'dark')
     root.classList.add(theme)
-    localStorage.setItem('panwatch-theme', theme)
-  }, [theme])
+    localStorage.setItem(STORAGE_KEY, mode)
+  }, [theme, mode])
 
-  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'))
+  // 兼容旧调用:在亮/暗间切换(会把模式落为显式 light/dark)
+  const toggleTheme = () => setMode(theme === 'dark' ? 'light' : 'dark')
 
-  return { theme, setTheme, toggleTheme }
+  return { theme, mode, setMode, toggleTheme }
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -80,40 +80,45 @@ export default function DashboardPage() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    const [idx, sc, ov, dg, bn, ht, td, at] = await Promise.allSettled([
+    // 快车道:DB/轻量查询,先让首屏(要紧事/指数/体检分布)尽快出来
+    const [idx, sc, ov, dg, ht, td] = await Promise.allSettled([
       dashboardApi.indices(),
       dashboardApi.intradayScan(),
       dashboardApi.overview({ market: 'ALL', action_limit: 6, risk_limit: 6 }),
       portfolioApi.diagnostics(),
-      portfolioApi.benchmark({ days: 60 }),
       homeApi.alertHitsToday(),
       homeApi.todos(),
-      portfolioApi.attribution(60),
     ])
     if (idx.status === 'fulfilled') setIndices(idx.value)
     if (sc.status === 'fulfilled') setScan(sc.value.stocks || [])
     if (ov.status === 'fulfilled') setOverview(ov.value)
     if (dg.status === 'fulfilled') setDiag(dg.value)
-    if (bn.status === 'fulfilled') setBench(bn.value)
     if (ht.status === 'fulfilled') setAlertHits(ht.value)
     if (td.status === 'fulfilled') setTodos(td.value.todos || [])
-    if (at.status === 'fulfilled') setAttribution(at.value.items || [])
+    setLoading(false) // 首屏不再等基准/归因(要拉全持仓 K 线)
+
+    // 机会兜底:overview 无机会时再取(不挡首屏)
     if (ov.status !== 'fulfilled' || !ov.value.action_center?.opportunities?.length) {
-      try {
-        const r = await recommendationsApi.listStrategySignals({ status: 'active', limit: 5 })
-        setOppFallback(r.items || [])
-      } catch {
-        /* ignore */
-      }
+      recommendationsApi
+        .listStrategySignals({ status: 'active', limit: 5 })
+        .then((r) => setOppFallback(r.items || []))
+        .catch(() => {})
     }
-    // 盘前/盘后简报:取较新的一条
-    const [pm, eod] = await Promise.allSettled([dashboardApi.brief('premarket'), dashboardApi.brief('eod')])
-    const briefs = [pm, eod]
-      .filter((b): b is PromiseFulfilledResult<DashboardBrief> => b.status === 'fulfilled' && !b.value.empty)
-      .map((b) => b.value)
-    briefs.sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''))
-    setBrief(briefs[0] || null)
-    setLoading(false)
+
+    // 慢车道:基准/归因需拉全持仓 K 线(40s 级),独立加载,就绪后回填超额/归因
+    Promise.allSettled([portfolioApi.benchmark({ days: 60 }), portfolioApi.attribution(60)]).then(([bn, at]) => {
+      if (bn.status === 'fulfilled') setBench(bn.value)
+      if (at.status === 'fulfilled') setAttribution(at.value.items || [])
+    })
+
+    // 盘前/盘后简报:独立加载,取较新一条
+    Promise.allSettled([dashboardApi.brief('premarket'), dashboardApi.brief('eod')]).then((res) => {
+      const briefs = res
+        .filter((b): b is PromiseFulfilledResult<DashboardBrief> => b.status === 'fulfilled' && !b.value.empty)
+        .map((b) => b.value)
+      briefs.sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''))
+      setBrief(briefs[0] || null)
+    })
   }, [])
 
   useEffect(() => {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Check, Eye, EyeOff, Plus, Pencil, Trash2, Star, Send, Cpu, Play, Download, Upload, FileJson, BarChart3, TrendingUp } from 'lucide-react'
 import { fetchAPI, type AIService, type AIModel, type NotifyChannel } from '@panwatch/api'
+import { useAvatar, saveAvatar, fileToAvatarDataUrl } from '@/hooks/use-avatar'
 import { Input } from '@panwatch/base-ui/components/ui/input'
 import { Label } from '@panwatch/base-ui/components/ui/label'
 import { Button } from '@panwatch/base-ui/components/ui/button'
@@ -169,6 +170,11 @@ export default function SettingsPage() {
   const [testing, setTesting] = useState<number | null>(null)
   const [testingModel, setTestingModel] = useState<number | null>(null)
 
+  // 头像
+  const avatar = useAvatar()
+  const avatarFileRef = useRef<HTMLInputElement | null>(null)
+  const [avatarSaving, setAvatarSaving] = useState(false)
+
   // Templates (config pack)
   const [importMode, setImportMode] = useState<'merge' | 'replace'>('merge')
   const [importing, setImporting] = useState(false)
@@ -318,6 +324,34 @@ export default function SettingsPage() {
   }
 
   useEffect(() => { load(); loadFeedbackStats() }, [])
+
+  const onPickAvatar = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = '' // 允许重复选择同一文件
+    if (!file) return
+    setAvatarSaving(true)
+    try {
+      const dataUrl = await fileToAvatarDataUrl(file)
+      await saveAvatar(dataUrl)
+      toast('头像已更新', 'success')
+    } catch (err) {
+      toast(err instanceof Error ? err.message : '头像保存失败', 'error')
+    } finally {
+      setAvatarSaving(false)
+    }
+  }
+
+  const onRemoveAvatar = async () => {
+    setAvatarSaving(true)
+    try {
+      await saveAvatar('')
+      toast('头像已移除', 'success')
+    } catch {
+      toast('操作失败', 'error')
+    } finally {
+      setAvatarSaving(false)
+    }
+  }
 
   const handleSave = async (key: string) => {
     setSaving(key)
@@ -560,22 +594,34 @@ export default function SettingsPage() {
         <div className="relative flex flex-col md:flex-row md:items-end md:justify-between gap-4">
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <div className="h-8 w-8 rounded-2xl bg-gradient-to-br from-primary to-primary/70 text-white shadow-sm flex items-center justify-center">
-                <TrendingUp className="w-4 h-4" />
-              </div>
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-mono text-foreground/90">PanWatch</span>
-                  <span className="rounded-full border border-border/50 bg-background/70 px-2 py-0.5 text-[10px] text-muted-foreground">Console</span>
-                </div>
-              </div>
-              {version ? <span className="opacity-60">v{version}</span> : null}
-              {health?.timezone ? (
-                <span className="opacity-60">TZ {health.timezone}</span>
+              <input ref={avatarFileRef} type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+              <button
+                type="button"
+                onClick={() => avatarFileRef.current?.click()}
+                disabled={avatarSaving}
+                title="点击上传头像"
+                className="group relative h-9 w-9 rounded-full overflow-hidden bg-gradient-to-br from-primary to-primary/70 text-white shadow-sm flex items-center justify-center ring-1 ring-border/40 hover:ring-primary/40 transition-all shrink-0"
+              >
+                {avatar ? (
+                  <img src={avatar} alt="头像" className="w-full h-full object-cover" />
+                ) : (
+                  <TrendingUp className="w-4 h-4" />
+                )}
+                <span className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <Upload className="w-3.5 h-3.5 text-white" />
+                </span>
+              </button>
+              {avatar ? (
+                <button
+                  type="button"
+                  onClick={onRemoveAvatar}
+                  disabled={avatarSaving}
+                  className="opacity-60 hover:text-destructive hover:opacity-100 transition-colors"
+                >
+                  移除头像
+                </button>
               ) : null}
             </div>
-            <h1 className="mt-1 text-[22px] md:text-[26px] font-bold text-foreground tracking-tight">设置</h1>
-            <p className="mt-1 text-[12px] md:text-[13px] text-muted-foreground">AI、通知与系统偏好。把“信息密度”和“打扰”调到你的手感。</p>
 
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <div className="px-2.5 py-1 rounded-full bg-background/70 border border-border/50 text-[11px] text-muted-foreground">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -593,7 +593,7 @@ export default function SettingsPage() {
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-accent/30" />
         <div className="relative flex flex-col md:flex-row md:items-end md:justify-between gap-4">
           <div className="min-w-0">
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
               <input ref={avatarFileRef} type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
               <button
                 type="button"
@@ -621,9 +621,7 @@ export default function SettingsPage() {
                   移除头像
                 </button>
               ) : null}
-            </div>
-
-            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <span className="mx-1 hidden h-4 w-px bg-border/50 sm:block" />
               <div className="px-2.5 py-1 rounded-full bg-background/70 border border-border/50 text-[11px] text-muted-foreground">
                 <span className="font-mono text-foreground/90">{services.length}</span> 服务商
               </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Check, Eye, EyeOff, Plus, Pencil, Trash2, Star, Send, Cpu, Play, Download, Upload, FileJson, BarChart3, TrendingUp } from 'lucide-react'
+import { Check, Eye, EyeOff, Plus, Pencil, Trash2, Star, Send, Cpu, Play, Download, Upload, FileJson, BarChart3, User } from 'lucide-react'
 import { fetchAPI, type AIService, type AIModel, type NotifyChannel } from '@panwatch/api'
 import { useAvatar, saveAvatar, fileToAvatarDataUrl } from '@/hooks/use-avatar'
 import { Input } from '@panwatch/base-ui/components/ui/input'
@@ -605,7 +605,7 @@ export default function SettingsPage() {
                 {avatar ? (
                   <img src={avatar} alt="头像" className="w-full h-full object-cover" />
                 ) : (
-                  <TrendingUp className="w-4 h-4" />
+                  <User className="w-4 h-4" />
                 )}
                 <span className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
                   <Upload className="w-3.5 h-3.5 text-white" />

--- a/src/collectors/kline_collector.py
+++ b/src/collectors/kline_collector.py
@@ -42,6 +42,25 @@ _KLINE_CACHE: dict[str, tuple[float, int, list["KlineData"]]] = {}
 _KLINE_TTL_TRADING_S = 180
 _KLINE_TTL_CLOSED_S = 1800
 
+# 失败负缓存:源短暂故障(Server disconnected/限流)时,冷却窗口内不再联网。
+# 复活的批量消费者(entry_candidates/strategy_engine/backtest/组合归因)会并发地
+# 对同一批标的取数,空结果若不缓存则每个消费者每轮都重复打爆数据源。
+_FAIL_UNTIL: dict[str, float] = {}
+_FAIL_COOLDOWN_S = 60.0
+# 同标的并发合并:同一 cache_key 的并发取数串行化,只联网一次,其余复用缓存。
+_FETCH_LOCKS: dict[str, threading.Lock] = {}
+_FETCH_LOCKS_GUARD = threading.Lock()
+
+
+def _get_fetch_lock(cache_key: str) -> threading.Lock:
+    """返回某 cache_key 的取数锁(进程内复用),用于合并同标的并发请求。"""
+    with _FETCH_LOCKS_GUARD:
+        lk = _FETCH_LOCKS.get(cache_key)
+        if lk is None:
+            lk = threading.Lock()
+            _FETCH_LOCKS[cache_key] = lk
+        return lk
+
 
 def _kline_cache_ttl(market: MarketCode) -> float:
     try:
@@ -54,8 +73,9 @@ def _kline_cache_ttl(market: MarketCode) -> float:
 
 
 def clear_kline_cache() -> None:
-    """清空 K线内存缓存(测试隔离用)。"""
+    """清空 K线内存缓存与失败冷却标记(测试隔离用)。"""
     _KLINE_CACHE.clear()
+    _FAIL_UNTIL.clear()
 
 
 def _fetch_stooq_us_klines(symbol: str) -> list[KlineData]:
@@ -626,19 +646,56 @@ class KlineCollector:
         self.market = market
 
     def get_klines(self, symbol: str, days: int = 60) -> list[KlineData]:
-        """获取日K线数据(按市场状态缓存,避免调度任务每轮重复联网触发限流)。"""
+        """获取日K线数据。
+
+        正缓存(按市场状态 TTL)+ 同标的并发合并(只联网一次)+ 失败负缓存
+        (源短暂故障时冷却窗口内不再联网),避免多消费者并发把数据源打爆。
+        """
         cache_key = f"{self.market.value}:{symbol}"
         need = max(1, int(days or 1))
-        now = time.time()
+
+        # 1) 快路径:命中新鲜正缓存,无需加锁
+        hit = self._cache_hit(cache_key, need)
+        if hit is not None:
+            return hit
+
+        # 2) 同标的并发合并:仅一个线程实际联网,其余等待后复用结果
+        with _get_fetch_lock(cache_key):
+            hit = self._cache_hit(cache_key, need)
+            if hit is not None:
+                return hit
+
+            now = time.time()
+            # 3) 负缓存:刚失败过的标的,冷却窗口内返回陈旧/空,不再联网
+            if now < _FAIL_UNTIL.get(cache_key, 0.0):
+                stale = _KLINE_CACHE.get(cache_key)
+                bars = stale[2] if stale else []
+                return bars[-need:] if len(bars) > need else bars
+
+            klines = self._fetch_all_sources(symbol, days)
+            if klines:
+                # 成功:固化正缓存并清除冷却标记
+                _KLINE_CACHE[cache_key] = (now, len(klines), list(klines))
+                _FAIL_UNTIL.pop(cache_key, None)
+            else:
+                # 失败:固化短冷却,挡住并发其余消费者与下一轮重复联网
+                _FAIL_UNTIL[cache_key] = now + _FAIL_COOLDOWN_S
+            return klines[-need:] if len(klines) > need else klines
+
+    def _cache_hit(self, cache_key: str, need: int) -> list[KlineData] | None:
+        """命中新鲜正缓存(TTL 内且条数足够)则返回切片,否则 None。"""
         cached = _KLINE_CACHE.get(cache_key)
         if (
             cached
-            and (now - cached[0]) < _kline_cache_ttl(self.market)
+            and (time.time() - cached[0]) < _kline_cache_ttl(self.market)
             and cached[1] >= need
         ):
             bars = cached[2]
             return bars[-need:] if len(bars) > need else bars
+        return None
 
+    def _fetch_all_sources(self, symbol: str, days: int) -> list[KlineData]:
+        """tencent → stooq(US) / eastmoney(CN/HK) 链路取数(不含缓存/合并逻辑)。"""
         klines = _fetch_tencent_klines(symbol, self.market, days)
 
         # Tencent 对部分美股返回的 day 数据异常偏少（仅 1-2 条），使用 Stooq 回退。
@@ -656,10 +713,7 @@ class KlineCollector:
                 if len(em) > len(klines):
                     klines = em
 
-        # 只缓存非空结果:数据源短暂故障时不把"空"固化,下轮可重试。
-        if klines:
-            _KLINE_CACHE[cache_key] = (now, len(klines), list(klines))
-        return klines[-need:] if len(klines) > need else klines
+        return klines
 
     def get_technical_indicators(
         self, symbol: str = "", klines: list[KlineData] | None = None

--- a/src/web/api/accounts.py
+++ b/src/web/api/accounts.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from src.web.database import get_db
 from src.web.models import Account, PriceAlertRule, Position, Stock
 from src.collectors.akshare_collector import _tencent_symbol, _fetch_tencent_quotes
+from src.collectors.market_http import TTLCache
 from src.models.market import MarketCode
 
 logger = logging.getLogger(__name__)
@@ -601,6 +602,25 @@ def _fetch_quotes_for_stocks(stocks: list[Stock]) -> dict:
     return quotes
 
 
+# 组合基准/归因结果缓存:重建全持仓 NAV 很贵(逐只拉 K 线),按持仓指纹缓存结果。
+# 持仓变动即失效(指纹变);失败/空结果不缓存,避免把瞬时故障冻住 10 分钟。
+_PORTFOLIO_RESULT_CACHE = TTLCache(default_ttl_sec=600.0)
+
+
+def _holdings_signature(db: Session) -> str:
+    """启用账户持仓的稳定指纹(stock_id + 合并后数量);仅查 DB,不拉行情/K 线。"""
+    rows = (
+        db.query(Position.stock_id, Position.quantity)
+        .join(Account, Account.id == Position.account_id)
+        .filter(Account.enabled == True)  # noqa: E712
+        .all()
+    )
+    agg: dict[int, float] = {}
+    for sid, qty in rows:
+        agg[sid] = agg.get(sid, 0.0) + (qty or 0)
+    return ";".join(f"{sid}:{agg[sid]:g}" for sid in sorted(agg))
+
+
 def _gather_holdings(db: Session) -> list[dict]:
     """汇总所有启用账户的真实持仓为统一列表(CNY 市值/浮盈 + fx),多账户同股合并。"""
     accounts = db.query(Account).filter(Account.enabled == True).all()  # noqa: E712
@@ -663,15 +683,24 @@ def portfolio_benchmark(
         build_portfolio_benchmark,
     )
 
+    days = max(20, min(int(days), 250))
+    bcode = benchmark or DEFAULT_BENCHMARK
+    sig = _holdings_signature(db)
+    if not sig:
+        return {"empty": True, "reason": "no_holdings"}
+    ckey = f"bench:{days}:{bcode}:{sig}"
+    cached = _PORTFOLIO_RESULT_CACHE.get(ckey)
+    if cached is not None:
+        return cached
+
     holdings = _gather_holdings(db)
     if not holdings:
         return {"empty": True, "reason": "no_holdings"}
-    days = max(20, min(int(days), 250))
-    res = build_portfolio_benchmark(
-        holdings, days=days, benchmark_code=(benchmark or DEFAULT_BENCHMARK)
-    )
+    res = build_portfolio_benchmark(holdings, days=days, benchmark_code=bcode)
     if not res:
+        # 失败/数据不足不缓存,下轮可重试(由 K 线负缓存兜住打爆)
         return {"empty": True, "reason": "insufficient_data"}
+    _PORTFOLIO_RESULT_CACHE.set(ckey, res)
     return res
 
 
@@ -731,11 +760,24 @@ def portfolio_attribution(days: int = 60, benchmark: str = "000300", db: Session
     """近 days 日各持仓对组合收益的贡献(谁拖累/贡献),降序。"""
     from src.core.portfolio_benchmark import DEFAULT_BENCHMARK, build_attribution
 
+    days = max(20, min(int(days), 250))
+    bcode = benchmark or DEFAULT_BENCHMARK
+    sig = _holdings_signature(db)
+    if not sig:
+        return {"items": []}
+    ckey = f"attr:{days}:{bcode}:{sig}"
+    cached = _PORTFOLIO_RESULT_CACHE.get(ckey)
+    if cached is not None:
+        return cached
+
     holdings = _gather_holdings(db)
     if not holdings:
         return {"items": []}
-    days = max(20, min(int(days), 250))
-    return {"items": build_attribution(holdings, days=days, benchmark_code=(benchmark or DEFAULT_BENCHMARK))}
+    items = build_attribution(holdings, days=days, benchmark_code=bcode)
+    result = {"items": items}
+    if items:  # 空结果不缓存,下轮可重试
+        _PORTFOLIO_RESULT_CACHE.set(ckey, result)
+    return result
 
 
 @router.post("/portfolio/ai-review")

--- a/src/web/api/settings.py
+++ b/src/web/api/settings.py
@@ -99,6 +99,29 @@ def list_settings(db: Session = Depends(get_db)):
     return result
 
 
+AVATAR_KEY = "ui_avatar"
+
+
+@router.get("/avatar")
+def get_avatar(db: Session = Depends(get_db)):
+    """用户头像(data URL 或图片地址)。单独存取,不混入通用设置列表。"""
+    row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
+    return {"value": (row.value if row and row.value else "")}
+
+
+@router.put("/avatar")
+def set_avatar(update: SettingUpdate, db: Session = Depends(get_db)):
+    """保存/清空用户头像(传空字符串即清空)。需在 /{key} 之前注册以优先匹配。"""
+    row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
+    if not row:
+        row = AppSettings(key=AVATAR_KEY, value=update.value or "", description="用户头像")
+        db.add(row)
+    else:
+        row.value = update.value or ""
+    db.commit()
+    return {"value": row.value or ""}
+
+
 @router.put("/{key}", response_model=SettingResponse)
 def update_setting(key: str, update: SettingUpdate, db: Session = Depends(get_db)):
     setting = db.query(AppSettings).filter(AppSettings.key == key).first()

--- a/src/web/api/settings.py
+++ b/src/web/api/settings.py
@@ -104,22 +104,14 @@ AVATAR_KEY = "ui_avatar"
 
 @router.get("/avatar")
 def get_avatar(db: Session = Depends(get_db)):
-    """用户头像(data URL 或图片地址)。单独存取,不混入通用设置列表。"""
+    """读取用户头像(data URL 或图片地址)。
+
+    头像通过通用 PUT /settings/{AVATAR_KEY} 写入(走 catch-all,不依赖路由注册顺序),
+    这里单独读取,避免大 base64 混进通用设置列表。GET /avatar 无 /{key} 同名 GET,
+    不存在路由抢匹配问题。
+    """
     row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
     return {"value": (row.value if row and row.value else "")}
-
-
-@router.put("/avatar")
-def set_avatar(update: SettingUpdate, db: Session = Depends(get_db)):
-    """保存/清空用户头像(传空字符串即清空)。需在 /{key} 之前注册以优先匹配。"""
-    row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
-    if not row:
-        row = AppSettings(key=AVATAR_KEY, value=update.value or "", description="用户头像")
-        db.add(row)
-    else:
-        row.value = update.value or ""
-    db.commit()
-    return {"value": row.value or ""}
 
 
 @router.put("/{key}", response_model=SettingResponse)

--- a/tests/test_avatar_setting.py
+++ b/tests/test_avatar_setting.py
@@ -1,0 +1,69 @@
+"""设置页头像:存取 + 路由优先级(PUT /avatar 不被 /{key} 抢匹配)+ 不污染通用设置列表。"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.web import models as M  # noqa: F401 (确保模型注册到 Base)
+from src.web.api import settings as settings_api
+from src.web.database import Base, get_db
+
+
+def _client() -> TestClient:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    app = FastAPI()
+    app.include_router(settings_api.router, prefix="/settings")
+
+    def _db():
+        s = Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _db
+    return TestClient(app)
+
+
+def test_avatar_default_empty():
+    """未设置时头像为空字符串。"""
+    client = _client()
+    r = client.get("/settings/avatar")
+    assert r.status_code == 200
+    assert r.json()["value"] == ""
+
+
+def test_avatar_set_get_roundtrip():
+    """PUT /avatar 后能 GET 回(验证 /avatar 不被 /{key} 抢匹配)。"""
+    client = _client()
+    data_url = "data:image/png;base64,AAAA"
+    r = client.put("/settings/avatar", json={"value": data_url})
+    assert r.status_code == 200, r.text
+    assert r.json()["value"] == data_url
+    assert client.get("/settings/avatar").json()["value"] == data_url
+
+
+def test_avatar_not_in_generic_list():
+    """头像存于独立 key,不应出现在通用设置列表(避免大 base64 污染)。"""
+    client = _client()
+    client.put("/settings/avatar", json={"value": "data:image/png;base64,XYZ"})
+    keys = [s["key"] for s in client.get("/settings").json()]
+    assert "ui_avatar" not in keys
+
+
+def test_avatar_clear():
+    """传空字符串可清空头像。"""
+    client = _client()
+    client.put("/settings/avatar", json={"value": "data:image/png;base64,XYZ"})
+    client.put("/settings/avatar", json={"value": ""})
+    assert client.get("/settings/avatar").json()["value"] == ""

--- a/tests/test_avatar_setting.py
+++ b/tests/test_avatar_setting.py
@@ -44,19 +44,18 @@ def test_avatar_default_empty():
 
 
 def test_avatar_set_get_roundtrip():
-    """PUT /avatar 后能 GET 回(验证 /avatar 不被 /{key} 抢匹配)。"""
+    """通用 PUT /settings/ui_avatar 写入后,GET /settings/avatar 能读回(读写不依赖路由顺序)。"""
     client = _client()
     data_url = "data:image/png;base64,AAAA"
-    r = client.put("/settings/avatar", json={"value": data_url})
+    r = client.put("/settings/ui_avatar", json={"value": data_url})
     assert r.status_code == 200, r.text
-    assert r.json()["value"] == data_url
     assert client.get("/settings/avatar").json()["value"] == data_url
 
 
 def test_avatar_not_in_generic_list():
     """头像存于独立 key,不应出现在通用设置列表(避免大 base64 污染)。"""
     client = _client()
-    client.put("/settings/avatar", json={"value": "data:image/png;base64,XYZ"})
+    client.put("/settings/ui_avatar", json={"value": "data:image/png;base64,XYZ"})
     keys = [s["key"] for s in client.get("/settings").json()]
     assert "ui_avatar" not in keys
 
@@ -64,6 +63,6 @@ def test_avatar_not_in_generic_list():
 def test_avatar_clear():
     """传空字符串可清空头像。"""
     client = _client()
-    client.put("/settings/avatar", json={"value": "data:image/png;base64,XYZ"})
-    client.put("/settings/avatar", json={"value": ""})
+    client.put("/settings/ui_avatar", json={"value": "data:image/png;base64,XYZ"})
+    client.put("/settings/ui_avatar", json={"value": ""})
     assert client.get("/settings/avatar").json()["value"] == ""

--- a/tests/test_kline_collector_cache.py
+++ b/tests/test_kline_collector_cache.py
@@ -69,8 +69,9 @@ def test_cache_serves_shorter_request_from_longer_entry(monkeypatch):
     assert len(out) == 30
 
 
-def test_empty_result_not_cached(monkeypatch):
-    """取数为空时不应写缓存,下一轮仍会重试(别把瞬时故障固化为空)。"""
+def test_empty_result_negative_cached_then_retries(monkeypatch):
+    """取数为空时进入短冷却:冷却窗口内不再联网(挡住并发/相邻消费者重复打爆源);
+    冷却过后仍会重试,不把瞬时故障永久固化为空。"""
     calls = {"n": 0}
 
     def fake_fetch(symbol, market, days):
@@ -83,7 +84,12 @@ def test_empty_result_not_cached(monkeypatch):
     c = kline_collector.KlineCollector(MarketCode.CN)
     assert c.get_klines("600519", days=120) == []
     assert c.get_klines("600519", days=120) == []
-    assert calls["n"] == 2, "空结果不应缓存,两次都应联网重试"
+    assert calls["n"] == 1, "冷却窗口内不应重复联网(防突发打爆数据源)"
+
+    # 模拟冷却到期:应重新联网重试,证明瞬时故障未被永久固化为空
+    kline_collector._FAIL_UNTIL.clear()
+    assert c.get_klines("600519", days=120) == []
+    assert calls["n"] == 2, "冷却过后应重新联网重试"
 
 
 def test_get_kline_summary_fetches_klines_once(monkeypatch):

--- a/tests/test_kline_fetch_coalesce.py
+++ b/tests/test_kline_fetch_coalesce.py
@@ -1,0 +1,92 @@
+"""K线获取:并发合并 + 失败负缓存。
+
+复活的 Phase 0-4 批量消费者(entry_candidates/strategy_engine/backtest)+ 组合归因
+会在收盘后并发地对同一批标的取 K 线。源短暂故障时,若失败结果既不缓存也不合并,
+每个并发消费者都会各自打一次 eastmoney(出现 "Server disconnected" 日志风暴),
+且空结果不缓存导致每轮重复打爆。这里固化两条防线:
+  1) 同一标的的并发取数合并为一次联网;
+  2) 取数失败后在冷却窗口内不再联网(负缓存)。
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from src.collectors import kline_collector as kc
+from src.models.market import MarketCode
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """每个用例前后清空进程级缓存,避免相互污染。"""
+    for name in ("_KLINE_CACHE", "_EASTMONEY_CACHE", "_FAIL_UNTIL", "_FETCH_LOCKS"):
+        d = getattr(kc, name, None)
+        if isinstance(d, dict):
+            d.clear()
+    yield
+    for name in ("_KLINE_CACHE", "_EASTMONEY_CACHE", "_FAIL_UNTIL", "_FETCH_LOCKS"):
+        d = getattr(kc, name, None)
+        if isinstance(d, dict):
+            d.clear()
+
+
+def test_failed_fetch_is_negative_cached(monkeypatch):
+    """同一标的取数失败后,冷却窗口内再次调用不再联网(负缓存)。"""
+    calls = {"n": 0}
+
+    def fake_tencent(symbol, market, days):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(kc, "_fetch_tencent_klines", fake_tencent)
+    monkeypatch.setattr(kc, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    col = kc.KlineCollector(MarketCode.CN)
+    assert col.get_klines("600519") == []
+    assert col.get_klines("600519") == []  # 冷却窗口内,应直接短路
+    assert calls["n"] == 1, f"失败后应负缓存,实际联网 {calls['n']} 次"
+
+
+def test_concurrent_same_symbol_fetches_coalesced(monkeypatch):
+    """同一标的的并发取数应合并为一次联网(防突发打爆数据源)。"""
+    calls = {"n": 0}
+    guard = threading.Lock()
+
+    def slow_tencent(symbol, market, days):
+        with guard:
+            calls["n"] += 1
+        time.sleep(0.25)
+        return []
+
+    monkeypatch.setattr(kc, "_fetch_tencent_klines", slow_tencent)
+    monkeypatch.setattr(kc, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    col = kc.KlineCollector(MarketCode.CN)
+    threads = [threading.Thread(target=lambda: col.get_klines("600519")) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert calls["n"] == 1, f"5 并发应合并为 1 次联网,实际 {calls['n']} 次"
+
+
+def test_different_symbols_not_blocked(monkeypatch):
+    """不同标的使用不同锁,不应相互阻塞(各自联网一次)。"""
+    calls = {"n": 0}
+    guard = threading.Lock()
+
+    def fake_tencent(symbol, market, days):
+        with guard:
+            calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(kc, "_fetch_tencent_klines", fake_tencent)
+    monkeypatch.setattr(kc, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    col = kc.KlineCollector(MarketCode.CN)
+    col.get_klines("600519")
+    col.get_klines("000001")
+    assert calls["n"] == 2, f"两个不同标的各应联网一次,实际 {calls['n']} 次"

--- a/tests/test_portfolio_result_cache.py
+++ b/tests/test_portfolio_result_cache.py
@@ -1,0 +1,121 @@
+"""组合基准/归因结果缓存:按持仓指纹缓存,持仓变动即失效,空结果不缓存。
+
+重建全持仓 NAV(逐只拉 K 线)很贵,首页又频繁请求基准/归因。这里按持仓指纹缓存结果,
+命中时跳过行情/K 线;持仓变化指纹即变 → 重算;失败/空结果不缓存,避免冻住瞬时故障。
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import src.core.portfolio_benchmark as pb
+from src.web import models as M
+from src.web.api import accounts as accounts_api
+from src.web.database import Base
+
+_HOLDINGS = [{"symbol": "600519", "market": "CN", "quantity": 100, "market_value": 100.0, "fx": 1.0}]
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    accounts_api._PORTFOLIO_RESULT_CACHE.clear()
+    try:
+        yield s
+    finally:
+        s.close()
+        accounts_api._PORTFOLIO_RESULT_CACHE.clear()
+
+
+def _add_position(db, symbol: str, qty: float):
+    acc = db.query(M.Account).first()
+    if not acc:
+        acc = M.Account(name="t", available_funds=0, enabled=True)
+        db.add(acc)
+        db.flush()
+    st = M.Stock(symbol=symbol, name=symbol, market="CN")
+    db.add(st)
+    db.flush()
+    db.add(M.Position(account_id=acc.id, stock_id=st.id, cost_price=1.0, quantity=qty))
+    db.commit()
+
+
+def test_benchmark_result_cached(db, monkeypatch):
+    """同一持仓的基准请求只计算一次,第二次命中缓存。"""
+    _add_position(db, "600519", 100)
+    calls = {"n": 0}
+
+    def fake_build(holdings, days=60, benchmark_code="000300"):
+        calls["n"] += 1
+        return {"excess_return": 1.23}
+
+    monkeypatch.setattr(accounts_api, "_gather_holdings", lambda d: list(_HOLDINGS))
+    monkeypatch.setattr(pb, "build_portfolio_benchmark", fake_build)
+
+    r1 = accounts_api.portfolio_benchmark(days=60, benchmark="000300", db=db)
+    r2 = accounts_api.portfolio_benchmark(days=60, benchmark="000300", db=db)
+    assert calls["n"] == 1, f"第二次应命中缓存,实际计算 {calls['n']} 次"
+    assert r1 == r2 == {"excess_return": 1.23}
+
+
+def test_benchmark_empty_not_cached(db, monkeypatch):
+    """数据不足(build 返回空)不缓存,下次仍会重算。"""
+    _add_position(db, "600519", 100)
+    calls = {"n": 0}
+
+    def fake_build(*a, **k):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(accounts_api, "_gather_holdings", lambda d: list(_HOLDINGS))
+    monkeypatch.setattr(pb, "build_portfolio_benchmark", fake_build)
+
+    r1 = accounts_api.portfolio_benchmark(db=db)
+    accounts_api.portfolio_benchmark(db=db)
+    assert calls["n"] == 2, "空结果不应缓存,应重算"
+    assert r1.get("empty") is True
+
+
+def test_benchmark_cache_invalidates_on_holdings_change(db, monkeypatch):
+    """持仓变化(指纹变)后应重新计算,不返回旧缓存。"""
+    _add_position(db, "600519", 100)
+    calls = {"n": 0}
+
+    def fake_build(*a, **k):
+        calls["n"] += 1
+        return {"excess_return": float(calls["n"])}
+
+    monkeypatch.setattr(accounts_api, "_gather_holdings", lambda d: list(_HOLDINGS))
+    monkeypatch.setattr(pb, "build_portfolio_benchmark", fake_build)
+
+    accounts_api.portfolio_benchmark(db=db)  # 计算 1,写缓存
+    _add_position(db, "000001", 50)  # 持仓变化 → 指纹变
+    accounts_api.portfolio_benchmark(db=db)  # 应重算
+    assert calls["n"] == 2, "持仓变化后缓存应失效"
+
+
+def test_attribution_result_cached(db, monkeypatch):
+    """归因结果同样按持仓指纹缓存。"""
+    _add_position(db, "600519", 100)
+    calls = {"n": 0}
+
+    def fake_attr(holdings, days=60, benchmark_code="000300"):
+        calls["n"] += 1
+        return [{"symbol": "600519", "contribution_pct": 1.0}]
+
+    monkeypatch.setattr(accounts_api, "_gather_holdings", lambda d: list(_HOLDINGS))
+    monkeypatch.setattr(pb, "build_attribution", fake_attr)
+
+    r1 = accounts_api.portfolio_attribution(db=db)
+    r2 = accounts_api.portfolio_attribution(db=db)
+    assert calls["n"] == 1, f"第二次应命中缓存,实际 {calls['n']} 次"
+    assert r1 == r2


### PR DESCRIPTION
## 现象
收盘后日志反复刷,同一标的**秒级内重复 ~5 条**,横跨整个自选池:
```
WARNING kline_collector Eastmoney 获取 601238 K线失败: Server disconnected without sending a response.
```

## 排查结论(先澄清怀疑)
怀疑 P0–P4 复活(两周前分支)回退了行情整治 —— **确认没回退**:`trust_env=False`(直连绕代理)、进程级节流、重试退避、正缓存都在;`TencentKlineProvider` 只是包 `KlineCollector`,无并行未整治路径。

真正缺口:`get_klines` **只缓存非空**且**无并发合并**。复活的批量消费者(`entry_candidates`/`strategy_engine`/`backtest`)+ 新增组合归因并发取同一批标的 —— 源短暂故障时每个消费者各打一次(故 ~5 条/标的),空结果不缓存致每轮重复打爆,自我强化。复测显示修复前正是 5 并发 → 5 次联网,与日志吻合。

## 修复(共享采集器两道防线)
- **同标的并发合并**:per-symbol 取数锁,同标的并发只联网一次、其余复用缓存(不同标的互不阻塞)。
- **失败负缓存**:全失败进入 60s 冷却,窗口内不联网(返回陈旧/空);冷却过后仍重试,不把瞬时故障永久固化为空。
- 抽出 `_cache_hit`/`_fetch_all_sources`;`clear_kline_cache` 一并清冷却标记。

> 并发合并必须配负缓存才对失败场景生效:否则等待者拿不到正缓存会各自重打。两者一起把"5 并发失败"收敛成"1 次联网 + 1 条日志"。

## 影响
失败联网量从 N×消费者/每轮 → 1×/60s/进程,日志风暴消除,并发压力下降也间接减少被限流概率。每标的仍可能 1 条失败日志(源确实拒绝),属预期降级。

## 测试
- 新增 `tests/test_kline_fetch_coalesce.py`:并发合并(5→1)/负缓存/不同标的不互阻
- 更新 `test_empty_result_*` 为冷却语义
- 全量 **338 passed, 1 skipped**(TDD:先 RED 复现 5→5 再 GREEN)