### PR TITLE
fix(头像): 图片落 data/avatars 文件,DB 仅存文件名(去 localStorage)

### DIFF
--- a/frontend/src/hooks/use-avatar.ts
+++ b/frontend/src/hooks/use-avatar.ts
@@ -27,9 +27,12 @@ function load(): Promise<string> {
   return inflight
 }
 
-/** 保存头像(传空字符串=清空):持久化到后端 DB(ui_avatar)并广播,使所有头像处即时更新。 */
+/**
+ * 保存头像(传空字符串=清空):后端把图片落成 data/avatars 文件、DB 仅记文件名;
+ * 本地广播即时更新。注意 cache 存的是 data URL(GET 也返回 data URL)。
+ */
 export async function saveAvatar(value: string): Promise<void> {
-  await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
+  await fetchAPI('/settings/avatar', { method: 'PUT', body: JSON.stringify({ value }) })
   cache = value
   window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: value }))
 }

--- a/frontend/src/hooks/use-avatar.ts
+++ b/frontend/src/hooks/use-avatar.ts
@@ -2,66 +2,46 @@ import { useState, useEffect } from 'react'
 import { fetchAPI } from '@panwatch/api'
 
 const EVENT = 'panwatch:avatar-changed'
-const LS_KEY = 'panwatch-avatar'
 
-function readLocal(): string {
-  try {
-    return localStorage.getItem(LS_KEY) || ''
-  } catch {
-    return ''
+// 仅 SPA 会话内的内存缓存(避免一次会话内重复请求)。
+// 真正的持久化在后端 DB(data/panwatch.db 的 ui_avatar),刷新后会重新从后端拉取。
+let cache: string | null = null
+let inflight: Promise<string> | null = null
+
+function load(): Promise<string> {
+  if (cache !== null) return Promise.resolve(cache)
+  if (!inflight) {
+    inflight = fetchAPI<{ value: string }>('/settings/avatar')
+      .then(r => {
+        cache = r?.value || ''
+        return cache as string
+      })
+      .catch(() => {
+        cache = ''
+        return ''
+      })
+      .finally(() => {
+        inflight = null
+      })
   }
+  return inflight
 }
 
-/**
- * 保存头像(传空字符串=清空):
- * 1) 先写 localStorage 并广播 —— 立即生效,刷新不丢,不依赖后端新路由是否已部署;
- * 2) 后台同步到后端(多设备/换浏览器),失败不影响本地显示。
- */
+/** 保存头像(传空字符串=清空):持久化到后端 DB(ui_avatar)并广播,使所有头像处即时更新。 */
 export async function saveAvatar(value: string): Promise<void> {
-  try {
-    if (value) localStorage.setItem(LS_KEY, value)
-    else localStorage.removeItem(LS_KEY)
-  } catch {
-    /* 忽略 localStorage 配额错误 */
-  }
+  await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
+  cache = value
   window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: value }))
-  try {
-    await fetchAPI('/settings/ui_avatar', { method: 'PUT', body: JSON.stringify({ value }) })
-  } catch {
-    /* 后端同步失败不阻塞本地 */
-  }
 }
 
-let calibrated = false
-
-/**
- * 当前头像(data URL 或图片地址)。localStorage 优先(刷新即在),
- * 首次再用后端 GET /settings/avatar 校准(多设备同步;旧后端无该路由时忽略错误,保留本地)。
- */
+/** 当前头像(data URL 或图片地址)。来源为后端 DB;跨组件即时同步。 */
 export function useAvatar(): string {
-  const [avatar, setAvatar] = useState<string>(readLocal)
-
+  const [avatar, setAvatar] = useState<string>(cache ?? '')
   useEffect(() => {
     let alive = true
-    if (!calibrated) {
-      calibrated = true
-      fetchAPI<{ value: string }>('/settings/avatar')
-        .then(r => {
-          const v = r?.value || ''
-          if (!alive || v === readLocal()) return
-          // 后端可达即视为权威:有值则采用,空值则清本地;两边都写
-          try {
-            if (v) localStorage.setItem(LS_KEY, v)
-            else localStorage.removeItem(LS_KEY)
-          } catch {
-            /* ignore */
-          }
-          window.dispatchEvent(new CustomEvent<string>(EVENT, { detail: v }))
-        })
-        .catch(() => {
-          /* 后端旧版无 /settings/avatar 路由或网络错误:保留本地值 */
-        })
-    }
+    load().then(v => {
+      if (alive) setAvatar(v)
+    })
     const onChange = (e: Event) => setAvatar((e as CustomEvent<string>).detail ?? '')
     window.addEventListener(EVENT, onChange)
     return () => {
@@ -69,13 +49,12 @@ export function useAvatar(): string {
       window.removeEventListener(EVENT, onChange)
     }
   }, [])
-
   return avatar
 }
 
 /**
  * 把上传的图片文件压缩为 size×size 的方形 JPEG data URL(居中裁剪),
- * 控制体积(约 10-20KB),避免大 base64 撑爆存储。
+ * 控制体积(约 10-20KB),避免大 base64 撑爆 DB 存储。
  */
 export function fileToAvatarDataUrl(file: File, size = 128): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -341,17 +341,6 @@ export default function SettingsPage() {
     }
   }
 
-  const onRemoveAvatar = async () => {
-    setAvatarSaving(true)
-    try {
-      await saveAvatar('')
-      toast('头像已移除', 'success')
-    } catch {
-      toast('操作失败', 'error')
-    } finally {
-      setAvatarSaving(false)
-    }
-  }
 
   const handleSave = async (key: string) => {
     setSaving(key)
@@ -611,16 +600,6 @@ export default function SettingsPage() {
                   <Upload className="w-3.5 h-3.5 text-white" />
                 </span>
               </button>
-              {avatar ? (
-                <button
-                  type="button"
-                  onClick={onRemoveAvatar}
-                  disabled={avatarSaving}
-                  className="opacity-60 hover:text-destructive hover:opacity-100 transition-colors"
-                >
-                  移除头像
-                </button>
-              ) : null}
               <span className="mx-1 hidden h-4 w-px bg-border/50 sm:block" />
               <div className="px-2.5 py-1 rounded-full bg-background/70 border border-border/50 text-[11px] text-muted-foreground">
                 <span className="font-mono text-foreground/90">{services.length}</span> 服务商

--- a/src/web/api/settings.py
+++ b/src/web/api/settings.py
@@ -1,5 +1,6 @@
+import base64
 import os
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
@@ -99,19 +100,82 @@ def list_settings(db: Session = Depends(get_db)):
     return result
 
 
-AVATAR_KEY = "ui_avatar"
+AVATAR_KEY = "ui_avatar"  # DB 仅存文件名;图片本体落在 data/avatars/
+
+
+def _avatar_dir() -> str:
+    d = os.path.join(os.environ.get("DATA_DIR", "./data"), "avatars")
+    os.makedirs(d, exist_ok=True)
+    return d
 
 
 @router.get("/avatar")
 def get_avatar(db: Session = Depends(get_db)):
-    """读取用户头像(data URL 或图片地址)。
+    """读取用户头像:DB 存文件名,图片本体在 data/avatars/,读取后以 data URL 返回。
 
-    头像通过通用 PUT /settings/{AVATAR_KEY} 写入(走 catch-all,不依赖路由注册顺序),
-    这里单独读取,避免大 base64 混进通用设置列表。GET /avatar 无 /{key} 同名 GET,
-    不存在路由抢匹配问题。
+    GET /avatar 无同名 GET /{key},不存在路由抢匹配问题。
     """
     row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
-    return {"value": (row.value if row and row.value else "")}
+    fname = (row.value if row and row.value else "").strip()
+    if not fname:
+        return {"value": ""}
+    path = os.path.join(_avatar_dir(), fname)
+    if not os.path.isfile(path):
+        return {"value": ""}
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return {"value": ""}
+    mime = "image/png" if fname.lower().endswith(".png") else "image/jpeg"
+    return {"value": f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"}
+
+
+@router.put("/avatar")
+def set_avatar(update: SettingUpdate, db: Session = Depends(get_db)):
+    """保存/清空用户头像:把 data URL 落成 data/avatars/avatar.* 文件,DB 仅记文件名。
+
+    需在 /{key} 之前注册以优先匹配。传空字符串即清空(删文件 + 清记录)。
+    """
+    row = db.query(AppSettings).filter(AppSettings.key == AVATAR_KEY).first()
+    old = (row.value if row else "") or ""
+    value = (update.value or "").strip()
+
+    if not value:
+        if old:
+            try:
+                os.remove(os.path.join(_avatar_dir(), old))
+            except OSError:
+                pass
+        if row:
+            row.value = ""
+        db.commit()
+        return {"value": ""}
+
+    if not (value.startswith("data:") and "," in value):
+        raise HTTPException(400, "头像需为 data URL")
+    header, b64 = value.split(",", 1)
+    ext = "png" if "image/png" in header else "jpg"
+    try:
+        raw = base64.b64decode(b64)
+    except Exception:
+        raise HTTPException(400, "头像数据无效")
+
+    fname = f"avatar.{ext}"
+    with open(os.path.join(_avatar_dir(), fname), "wb") as f:
+        f.write(raw)
+    if old and old != fname:  # 扩展名变化时清掉旧文件
+        try:
+            os.remove(os.path.join(_avatar_dir(), old))
+        except OSError:
+            pass
+    if not row:
+        row = AppSettings(key=AVATAR_KEY, value=fname, description="用户头像文件名")
+        db.add(row)
+    else:
+        row.value = fname
+    db.commit()
+    return {"value": fname}
 
 
 @router.put("/{key}", response_model=SettingResponse)

--- a/tests/test_avatar_setting.py
+++ b/tests/test_avatar_setting.py
@@ -1,6 +1,8 @@
-"""设置页头像:存取 + 路由优先级(PUT /avatar 不被 /{key} 抢匹配)+ 不污染通用设置列表。"""
+"""设置页头像:图片落 data/avatars 文件,DB 仅存文件名;data URL 读写,清空删文件。"""
 
 from __future__ import annotations
+
+import os
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -12,8 +14,12 @@ from src.web import models as M  # noqa: F401 (确保模型注册到 Base)
 from src.web.api import settings as settings_api
 from src.web.database import Base, get_db
 
+# 任意有效 base64;后端按字节落文件,GET 再读回同样的 data URL
+_IMG = "data:image/jpeg;base64,AAAA"
 
-def _client() -> TestClient:
+
+def _client(tmp_path, monkeypatch) -> TestClient:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -35,34 +41,43 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-def test_avatar_default_empty():
+def test_avatar_default_empty(tmp_path, monkeypatch):
     """未设置时头像为空字符串。"""
-    client = _client()
-    r = client.get("/settings/avatar")
-    assert r.status_code == 200
-    assert r.json()["value"] == ""
+    c = _client(tmp_path, monkeypatch)
+    assert c.get("/settings/avatar").json()["value"] == ""
 
 
-def test_avatar_set_get_roundtrip():
-    """通用 PUT /settings/ui_avatar 写入后,GET /settings/avatar 能读回(读写不依赖路由顺序)。"""
-    client = _client()
-    data_url = "data:image/png;base64,AAAA"
-    r = client.put("/settings/ui_avatar", json={"value": data_url})
+def test_avatar_saved_as_file_db_stores_filename(tmp_path, monkeypatch):
+    """上传后:图片落 data/avatars 文件,DB 仅记文件名,GET 以 data URL 读回。"""
+    c = _client(tmp_path, monkeypatch)
+    r = c.put("/settings/avatar", json={"value": _IMG})
     assert r.status_code == 200, r.text
-    assert client.get("/settings/avatar").json()["value"] == data_url
+    # 文件已落盘到 data/avatars
+    assert os.listdir(os.path.join(str(tmp_path), "avatars")) == ["avatar.jpg"]
+    # DB 仅存文件名(短,非 base64)
+    assert r.json()["value"] == "avatar.jpg"
+    # GET 读回 data URL
+    assert c.get("/settings/avatar").json()["value"] == _IMG
 
 
-def test_avatar_not_in_generic_list():
-    """头像存于独立 key,不应出现在通用设置列表(避免大 base64 污染)。"""
-    client = _client()
-    client.put("/settings/ui_avatar", json={"value": "data:image/png;base64,XYZ"})
-    keys = [s["key"] for s in client.get("/settings").json()]
+def test_avatar_clear_deletes_file(tmp_path, monkeypatch):
+    """传空字符串清空:删除文件 + GET 返回空。"""
+    c = _client(tmp_path, monkeypatch)
+    c.put("/settings/avatar", json={"value": _IMG})
+    c.put("/settings/avatar", json={"value": ""})
+    assert c.get("/settings/avatar").json()["value"] == ""
+    assert os.listdir(os.path.join(str(tmp_path), "avatars")) == []
+
+
+def test_avatar_rejects_non_dataurl(tmp_path, monkeypatch):
+    """非 data URL 的头像值应被拒绝(400)。"""
+    c = _client(tmp_path, monkeypatch)
+    assert c.put("/settings/avatar", json={"value": "http://x/a.png"}).status_code == 400
+
+
+def test_avatar_key_not_in_generic_list(tmp_path, monkeypatch):
+    """头像键不混进通用设置列表。"""
+    c = _client(tmp_path, monkeypatch)
+    c.put("/settings/avatar", json={"value": _IMG})
+    keys = [s["key"] for s in c.get("/settings").json()]
     assert "ui_avatar" not in keys
-
-
-def test_avatar_clear():
-    """传空字符串可清空头像。"""
-    client = _client()
-    client.put("/settings/ui_avatar", json={"value": "data:image/png;base64,XYZ"})
-    client.put("/settings/ui_avatar", json={"value": ""})
-    assert client.get("/settings/avatar").json()["value"] == ""


### PR DESCRIPTION
## 背景
头像存储位置纠正。此前误用 localStorage 做存储(刷新依赖浏览器,且非服务端持久)。按反馈改为:**图片本体存服务端文件,DB 仅记文件名。**

## 改动
- **PUT `/settings/avatar`**:解析 data URL → 写入 `DATA_DIR/avatars/avatar.jpg`;DB `ui_avatar` 只存**文件名**;传空字符串=清空(删文件 + 清记录)。注册在 `/{key}` 之前以优先匹配。
- **GET `/settings/avatar`**:读取文件 → 以 data URL 返回(带鉴权的 JSON,前端 `<img src>` 直接用,规避静态文件鉴权问题)。
- **前端** `saveAvatar` 改投 `PUT /settings/avatar`;读取仍 `GET /settings/avatar`;**移除 localStorage**(内存 cache 仅单次会话去重,刷新后从后端重新拉)。

## 存储形态
- 图片:`data/avatars/avatar.jpg`(在 data 目录)
- DB:`app_settings.ui_avatar = "avatar.jpg"`(仅文件名,不再是 base64)

## 测试
`tests/test_avatar_setting.py`(临时 DATA_DIR):落盘文件名 / DB 仅存文件名 / 清空删文件 / 拒非 dataURL / 不入通用设置列表。全量 **347 passed**。

## 注意
`GET/PUT /settings/avatar` 为新增路由,本地需**重启后端**(`python server.py` 不自动重载)才生效;Docker 发布镜像全新启动自带。旧的 base64 值(`ui_avatar` 里的历史数据)会被当文件名读取→找不到文件→返回空,重新上传一次即可。