### PR TITLE
fix(test): 会话级建表 fixture 修复 CI 全新环境 'no such table'(解阻 0.9.0 发布)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,21 @@ def _clear_market_caches():
     _clear()
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _ensure_db_schema():
+    """确保真实 DB 引擎已建表。
+
+    少数用例直接用 SessionLocal 传给 async 接口(只读查询),CI 全新环境的
+    data/panwatch.db 无表会报 'no such table: stocks'。这里在会话开始时幂等建表
+    (本地已有表则无副作用),与各用例自建的内存库互不影响。
+    """
+    from src.web import models  # noqa: F401  注册所有 ORM 模型到 Base.metadata
+    from src.web.database import Base, engine
+
+    Base.metadata.create_all(engine)
+    yield
+
+
 # ---------------------------------------------------------------------------
 # 共用工厂 fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题
0.9.0 release CI 在测试步骤失败:`no such table: stocks`。

`test_announcement_eval` / `test_curate` / `test_add_position_eval` 直接用 `SessionLocal()` 传给 async 接口做只读查询。本地 `data/panwatch.db` 已有表所以一直通过;CI 全新 runner 的 DB 无表 → 报错。这几个测试是 0.8.7 之后(#52)新增的,0.9.0 是首个在干净 CI 跑到它们的发布。

## 修复
`conftest.py` 增加 session 级 autouse fixture,幂等 `Base.metadata.create_all(engine)`。本地已有表则无副作用;与各用例自建内存库互不影响。

## 验证
用空 DB 跑**完整 CI 命令** `pytest tests/ -x -q` → **347 passed, 1 skipped**。