### PR TITLE
fix: 生产两处报错 — outcome_eval HK 取K线刷屏 + TA load_ohlcv 绕过注入(yfinance NoMarketData)

### DIFF
--- a/src/agents/tradingagents/toolkit_adapter.py
+++ b/src/agents/tradingagents/toolkit_adapter.py
@@ -330,6 +330,10 @@ def patch_route_to_vendor():
         yield
         return
 
+    # 同时接管 load_ohlcv:新上游 get_verified_market_snapshot 绕过 route_to_vendor
+    # 直连 yfinance,A股/港股拉不到会 NoMarketDataError(永久安装,非 PanWatch 标的透传)。
+    _ensure_load_ohlcv_patched()
+
     import importlib
     with _patch_lock:
         if _patch_refcount == 0:
@@ -361,6 +365,99 @@ def patch_route_to_vendor():
                 for mod, attr, orig in _patch_saved_sites:
                     setattr(mod, attr, orig)
                 _patch_saved_sites.clear()
+
+
+# ---------------------------------------------------------------------------
+# load_ohlcv 接管
+# 新上游 get_verified_market_snapshot → market_data_validator.load_ohlcv 直连 yfinance,
+# 不经 route_to_vendor。A股(无 .SS)/港股(无 .HK)yfinance 拉不到 → NoMarketDataError,
+# 整个 TradingAgents 分析失败。这里把 A股/港股的 load_ohlcv 改走 PanWatch K线;
+# 非 PanWatch 标的(美股)透传原生 yfinance,故进程级永久安装安全、无需卸载。
+# ---------------------------------------------------------------------------
+_LOAD_OHLCV_PATCHED = False
+_real_load_ohlcv: Any = None
+_LOAD_OHLCV_IMPORT_SITES = (
+    "tradingagents.dataflows.market_data_validator",
+    "tradingagents.dataflows.interface",
+)
+
+
+def _build_panwatch_ohlcv_df(symbol: str, curr_date: str):
+    """用 PanWatch K线构建与原生 load_ohlcv 同结构的 DataFrame(Date/Open/High/Low/Close/Volume)。"""
+    import pandas as pd
+
+    from src.collectors.kline_collector import KlineCollector
+    from src.models.market import MarketCode
+
+    market = MarketCode.CN if is_a_share(symbol) else MarketCode.HK
+    klines = KlineCollector(market).get_klines(symbol, days=750)
+    if not klines:
+        return None
+    df = pd.DataFrame(
+        [
+            {
+                "Date": k.date,
+                "Open": k.open,
+                "High": k.high,
+                "Low": k.low,
+                "Close": k.close,
+                "Volume": k.volume,
+            }
+            for k in klines
+        ]
+    )
+    df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+    df = df.dropna(subset=["Date"])
+    if curr_date:
+        try:
+            df = df[df["Date"] <= pd.to_datetime(curr_date)]
+        except Exception:
+            pass
+    return df.reset_index(drop=True)
+
+
+def _panwatch_load_ohlcv(symbol: str, curr_date: str, *args, **kwargs):
+    """A股/港股用 PanWatch K线构建 OHLCV;其余或兜底失败放行原生 yfinance 路径。"""
+    try:
+        if is_panwatch_routable(symbol):
+            df = _build_panwatch_ohlcv_df(symbol, curr_date)
+            if df is not None and not df.empty:
+                _emit_toolkit_log("info", "panwatch", "load_ohlcv", symbol, rows=int(len(df)))
+                return df
+            _emit_toolkit_log("warning", "miss", "load_ohlcv", symbol)
+    except Exception as e:
+        logger.warning(f"[TA toolkit] load_ohlcv PanWatch 兜底失败 symbol={symbol}: {e}")
+    return _real_load_ohlcv(symbol, curr_date, *args, **kwargs)
+
+
+def _ensure_load_ohlcv_patched() -> None:
+    """进程级幂等安装 load_ohlcv 补丁(含所有 import sites);非 PanWatch 标的透传,无需卸载。"""
+    global _LOAD_OHLCV_PATCHED, _real_load_ohlcv
+    if _LOAD_OHLCV_PATCHED:
+        return
+    try:
+        from tradingagents.dataflows import stockstats_utils
+    except ImportError:
+        return
+    if not hasattr(stockstats_utils, "load_ohlcv"):
+        return
+    import importlib
+
+    with _patch_lock:
+        if _LOAD_OHLCV_PATCHED:
+            return
+        _real_load_ohlcv = stockstats_utils.load_ohlcv
+        stockstats_utils.load_ohlcv = _panwatch_load_ohlcv
+        for module_path in _LOAD_OHLCV_IMPORT_SITES:
+            try:
+                mod = importlib.import_module(module_path)
+            except ImportError:
+                continue
+            if getattr(mod, "load_ohlcv", None) is not None:
+                mod.load_ohlcv = _panwatch_load_ohlcv
+                logger.debug(f"[TA toolkit] patched load_ohlcv in {module_path}")
+        _LOAD_OHLCV_PATCHED = True
+        logger.info("[TA toolkit] load_ohlcv 已接管(A股/港股走 PanWatch,防 yfinance NoMarketData)")
 
 
 def _args_summary(args: tuple) -> str:

--- a/src/collectors/kline_collector.py
+++ b/src/collectors/kline_collector.py
@@ -46,7 +46,21 @@ _KLINE_TTL_CLOSED_S = 1800
 # 复活的批量消费者(entry_candidates/strategy_engine/backtest/组合归因)会并发地
 # 对同一批标的取数,空结果若不缓存则每个消费者每轮都重复打爆数据源。
 _FAIL_UNTIL: dict[str, float] = {}
-_FAIL_COOLDOWN_S = 60.0
+_FAIL_COOLDOWN_S = 60.0  # 交易时段:短冷却,便于尽快重试
+_FAIL_COOLDOWN_CLOSED_S = 900.0  # 收盘后:数据已定稿,失败/不足时长冷却,避免批量任务反复刷屏
+
+
+def _fail_cooldown(market: MarketCode) -> float:
+    """取数失败/不足时的冷却时长:交易时段短(尽快重试),收盘后长(重试无意义且易刷屏)。"""
+    try:
+        md = MARKETS.get(market)
+        if md and md.is_trading_time():
+            return _FAIL_COOLDOWN_S
+    except Exception:
+        pass
+    return _FAIL_COOLDOWN_CLOSED_S
+
+
 # 同标的并发合并:同一 cache_key 的并发取数串行化,只联网一次,其余复用缓存。
 _FETCH_LOCKS: dict[str, threading.Lock] = {}
 _FETCH_LOCKS_GUARD = threading.Lock()
@@ -673,13 +687,17 @@ class KlineCollector:
                 return bars[-need:] if len(bars) > need else bars
 
             klines = self._fetch_all_sources(symbol, days)
-            if klines:
-                # 成功:固化正缓存并清除冷却标记
+            if klines and len(klines) >= need:
+                # 成功且条数足够:固化正缓存并清除冷却标记
                 _KLINE_CACHE[cache_key] = (now, len(klines), list(klines))
                 _FAIL_UNTIL.pop(cache_key, None)
             else:
-                # 失败:固化短冷却,挡住并发其余消费者与下一轮重复联网
-                _FAIL_UNTIL[cache_key] = now + _FAIL_COOLDOWN_S
+                # 空 或 拿到部分但不足 need(常见:HK 腾讯不足 + eastmoney 补全失败,
+                # 正缓存因 count<need 永不命中 → 每轮重打补全源刷屏)→ 固化冷却。
+                # 部分结果仍缓存下来,冷却窗口内直接服务,避免反复联网。
+                if klines:
+                    _KLINE_CACHE[cache_key] = (now, len(klines), list(klines))
+                _FAIL_UNTIL[cache_key] = now + _fail_cooldown(self.market)
             return klines[-need:] if len(klines) > need else klines
 
     def _cache_hit(self, cache_key: str, need: int) -> list[KlineData] | None:

--- a/tests/test_kline_fetch_coalesce.py
+++ b/tests/test_kline_fetch_coalesce.py
@@ -90,3 +90,27 @@ def test_different_symbols_not_blocked(monkeypatch):
     col.get_klines("600519")
     col.get_klines("000001")
     assert calls["n"] == 2, f"两个不同标的各应联网一次,实际 {calls['n']} 次"
+
+
+def test_insufficient_result_negative_cached(monkeypatch):
+    """取到数据但不足 need(HK 腾讯少量 + eastmoney 补全失败)→ 冷却内不再联网。
+
+    复现 outcome_eval 刷屏:正缓存因 count<need 永不命中,旧逻辑只在"空结果"时负缓存,
+    导致每轮都重打 eastmoney 补全源。
+    """
+    calls = {"n": 0}
+
+    def short_tencent(symbol, market, days):
+        calls["n"] += 1
+        return [
+            kc.KlineData(date=f"2026-01-{i + 1:02d}", open=1, close=1, high=1, low=1, volume=1)
+            for i in range(30)
+        ]
+
+    monkeypatch.setattr(kc, "_fetch_tencent_klines", short_tencent)
+    monkeypatch.setattr(kc, "_fetch_eastmoney_klines", lambda *a, **k: [])
+
+    col = kc.KlineCollector(MarketCode.HK)
+    col.get_klines("06082", days=120)  # 拿到 30 < need(120) → 冷却 + 缓存部分
+    col.get_klines("06082", days=120)  # 冷却内,服务缓存,不再联网
+    assert calls["n"] == 1, f"不足 need 时也应负缓存,实际联网 {calls['n']} 次"

--- a/tests/test_ta_load_ohlcv_patch.py
+++ b/tests/test_ta_load_ohlcv_patch.py
@@ -1,0 +1,71 @@
+"""TA load_ohlcv 接管:A股/港股走 PanWatch K线,美股透传 yfinance。
+
+新上游 get_verified_market_snapshot → load_ohlcv 直连 yfinance,A股(无 .SS)拉不到
+→ NoMarketDataError 整个分析失败。这里验证 PanWatch 接管能为 A股构建 OHLCV,且不误伤美股。
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from src.agents.tradingagents import toolkit_adapter as ta
+from src.collectors.kline_collector import KlineCollector, KlineData
+
+
+def _sample_klines(n: int = 40) -> list[KlineData]:
+    base = date(2026, 4, 1)
+    return [
+        KlineData(
+            date=str(base + timedelta(days=i)),
+            open=1.0 + i,
+            close=2.0 + i,
+            high=3.0 + i,
+            low=0.5 + i,
+            volume=100.0 + i,
+        )
+        for i in range(n)
+    ]
+
+
+def test_build_df_columns_and_date_filter(monkeypatch):
+    """构建的 DataFrame 含 Date/OHLCV 列,Date 为 datetime,且按 curr_date 截断。"""
+    monkeypatch.setattr(KlineCollector, "get_klines", lambda self, symbol, days=60: _sample_klines(40))
+    df = ta._build_panwatch_ohlcv_df("601238", "2026-04-20")
+    assert list(df.columns) == ["Date", "Open", "High", "Low", "Close", "Volume"]
+    assert str(df["Date"].dtype).startswith("datetime64")
+    assert (df["Date"] <= pd.to_datetime("2026-04-20")).all()
+    assert len(df) == 20  # 04-01..04-20
+
+
+def test_load_ohlcv_routes_a_share_to_panwatch(monkeypatch):
+    """A股调用走 PanWatch,不触发原生 yfinance load_ohlcv。"""
+    monkeypatch.setattr(KlineCollector, "get_klines", lambda self, symbol, days=60: _sample_klines(10))
+    real_calls = {"n": 0}
+
+    def fake_real(*a, **k):
+        real_calls["n"] += 1
+        return pd.DataFrame()
+
+    monkeypatch.setattr(ta, "_real_load_ohlcv", fake_real)
+    df = ta._panwatch_load_ohlcv("601238", "2026-06-18")
+    assert not df.empty
+    assert real_calls["n"] == 0, "A股不应回落到 yfinance"
+
+
+def test_load_ohlcv_passthrough_for_us(monkeypatch):
+    """美股放行原生 load_ohlcv(yfinance),不被 PanWatch 接管。"""
+    sentinel = pd.DataFrame({"Date": [pd.to_datetime("2026-01-01")], "Close": [1.0]})
+    monkeypatch.setattr(ta, "_real_load_ohlcv", lambda symbol, curr_date, *a, **k: sentinel)
+    out = ta._panwatch_load_ohlcv("AAPL", "2026-06-18")
+    assert out is sentinel
+
+
+def test_load_ohlcv_falls_back_when_no_klines(monkeypatch):
+    """A股但取不到 K线时,兜底回落原生路径(不抛错)。"""
+    monkeypatch.setattr(KlineCollector, "get_klines", lambda self, symbol, days=60: [])
+    sentinel = pd.DataFrame({"Date": [pd.to_datetime("2026-01-01")], "Close": [1.0]})
+    monkeypatch.setattr(ta, "_real_load_ohlcv", lambda symbol, curr_date, *a, **k: sentinel)
+    out = ta._panwatch_load_ohlcv("601238", "2026-06-18")
+    assert out is sentinel


### PR DESCRIPTION
两处生产报错(日志定位)。

## 1) K线刷屏 [src=outcome_eval]
`prediction_outcome` 批量评估对**港股**取 K 线。HK 腾讯常返回少量(<need),eastmoney 补全失败 → 结果**非空但 count<need** → 正缓存 `_cache_hit`(要 `count>=need`)**永不命中** → 每轮重打 eastmoney,`Server disconnected` 刷屏。原负缓存只在"空结果"时生效,漏了"部分但不足"。
- `get_klines`:空 **或** `len<need` 都进负缓存,并把部分结果缓存供冷却窗口内服务
- 冷却时长按市场状态:**交易 60s / 收盘 900s**(收盘数据已定稿,重试无意义且最易刷屏)

## 2) TradingAgents 对 A股硬失败
`601238` 分析失败:新上游 `get_verified_market_snapshot` → `market_data_validator.load_ohlcv` **直连 yfinance**,绕过 PanWatch 的 `route_to_vendor` 补丁。A股无 `.SS`/港股无 `.HK` → Yahoo 返回 0 行 → `NoMarketDataError` → 整个分析失败。(`get_stock_data`/财报等已注入,唯独这个新校验工具没覆盖。)
- 新增 `_panwatch_load_ohlcv`:A股/港股用 `KlineCollector` 构建 OHLCV DataFrame(列同原生 `Date/Open/High/Low/Close/Volume`),其余/兜底失败**透传原生 yfinance**
- 进程级幂等永久安装(patch 源头 + `market_data_validator` 等 import sites),在 `patch_route_to_vendor` 入口装上;非 PanWatch 标的透传,故永久安装安全

## 测试
- `test_kline_fetch_coalesce`:不足 need 也负缓存(二次不再联网)
- `test_ta_load_ohlcv_patch`:列/日期截断 / A股走 PanWatch / 美股透传 / 无K线兜底
- 全量 **352 passed**