### PR TITLE
fix(TA): 锁定 tradingagents 到 v0.2.5 + 上游 vendor 失败降级(止住反复报错)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,8 @@ PyJWT>=2.8.0
 # 不在 PyPI,用 git+ URL 安装。会拉 langchain/langgraph/yfinance 等较重依赖
 # (~115 个包,首次安装 2-5 分钟)。
 # 用户启用「TradingAgents 深度分析」Agent 时才会真正调用它;不启用零开销。
-tradingagents @ git+https://github.com/TauricResearch/TradingAgents.git@main
+# 锁定到 v0.2.5(而非 @main):上游 main 不断加需外部 key/服务的新工具
+# (get_verified_market_snapshot→yfinance、get_macro_indicators→FRED、polymarket 等),
+# 我们的注入层未覆盖就会硬失败。v0.2.5 是 PanWatch 适配/测试的稳定版,不含这些工具。
+# 升级前需先在适配层(toolkit_adapter)对新工具做覆盖/降级。
+tradingagents @ git+https://github.com/TauricResearch/TradingAgents.git@v0.2.5

--- a/src/agents/tradingagents/toolkit_adapter.py
+++ b/src/agents/tradingagents/toolkit_adapter.py
@@ -287,8 +287,18 @@ def _patched_route_to_vendor(method_name: str, *args, **kwargs):
             _emit_toolkit_log("warning", "ERROR", method_name, symbol, error=str(e)[:200])
             return f"[关键词新闻搜索失败「{symbol}」: {e}]"
 
-    # 美股 / 其他:直接走上游 vendor
-    upstream_result = _real_route_to_vendor(method_name, *args, **kwargs)
+    # 美股 / 其他:直接走上游 vendor。
+    # 降级兜底:上游某些工具依赖外部 key/服务(FRED 无 key、polymarket SSL、未配置 vendor 等),
+    # 失败会抛异常拖垮整个深度分析。这里捕获并返回空 —— 单个工具缺数据 ≠ 整轮失败。
+    try:
+        upstream_result = _real_route_to_vendor(method_name, *args, **kwargs)
+    except Exception as e:
+        logger.warning(f"[TA toolkit] 上游 {method_name} 失败,降级返回空(不中断分析): {e}")
+        _emit_toolkit_log(
+            "warning", "DEGRADE", method_name, symbol or "(none)",
+            error=str(e)[:200], extra_args=_args_summary(args),
+        )
+        return ""
     upstream_str = str(upstream_result) if upstream_result is not None else ""
     action_label = "PASSTHROUGH" if not is_a_share(symbol) else "FALLTHROUGH"
     _emit_toolkit_log(

--- a/tests/test_ta_load_ohlcv_patch.py
+++ b/tests/test_ta_load_ohlcv_patch.py
@@ -69,3 +69,15 @@ def test_load_ohlcv_falls_back_when_no_klines(monkeypatch):
     monkeypatch.setattr(ta, "_real_load_ohlcv", lambda symbol, curr_date, *a, **k: sentinel)
     out = ta._panwatch_load_ohlcv("601238", "2026-06-18")
     assert out is sentinel
+
+
+def test_route_to_vendor_degrades_on_upstream_error(monkeypatch):
+    """上游 vendor 失败(如 FRED 无 key、polymarket SSL)应降级返回空,不抛错中断整轮分析。"""
+
+    def boom(method_name, *a, **k):
+        raise RuntimeError("FRED_API_KEY environment variable is not set")
+
+    monkeypatch.setattr(ta, "_real_route_to_vendor", boom)
+    # get_macro_indicators:首参是指标名(非 A股/港股) → 走上游 passthrough → boom → 降级空
+    out = ta._patched_route_to_vendor("get_macro_indicators", "fed_funds_rate", "2026-06-18", 30)
+    assert out == ""


### PR DESCRIPTION
## 为什么反复报错(根因)
`requirements.txt` 之前是 `tradingagents @ ...@main` —— **跟着上游 main 漂移**。上游不断加需要外部 key/服务的新工具,而我们的注入层(`toolkit_adapter`)没覆盖到就**硬失败**,每修一个又冒下一个:
1. `get_verified_market_snapshot` → yfinance(A股无 `.SS`)→ 0.9.1 修了 `load_ohlcv`
2. 过了市场数据,又撞 `get_macro_indicators` → **FRED**(无 `FRED_API_KEY`)→ `FredNotConfiguredError`
3. 还有 polymarket SSL(非致命)

**本地 dev 是 v0.2.5,根本没有这些工具** —— 它们都是 v0.2.5 之后加到 main 的。

## 修复
- **锁版本**:`@main` → `@v0.2.5`(最新稳定 tag,= 本地 dev,不含上述新工具 → 三个雷一次性消除)。升级前需先在适配层覆盖新工具。
- **降级兜底**:`_patched_route_to_vendor` 的上游 passthrough 包 `try/except` —— vendor 失败(FRED 无 key、polymarket SSL、未配置 vendor 等)**降级返回空**,单个工具缺数据不再拖垮整轮分析(防将来再撞新工具)。

## 测试
`test_ta_load_ohlcv_patch`:新增"上游失败降级返回空";全量 **353 passed**。

## 注意
要重建镜像才会装上 v0.2.5(`requirements` 是构建期依赖)→ 需发新版(0.9.2)。