### PR TITLE
feat(report): 深度分析详情报告导出 PDF(WeasyPrint,完整内容)

### DIFF
--- a/frontend/packages/api/src/tradingagents.ts
+++ b/frontend/packages/api/src/tradingagents.ts
@@ -3,7 +3,7 @@
  * 复用现有 /api/stocks/:id/agents/:name/trigger,只是 agent_name = "tradingagents"。
  * 进度走新增的 /api/agents/runs/:trace_id/progress。
  */
-import { fetchAPI } from './client'
+import { fetchAPI, getToken } from './client'
 
 export interface TradingAgentsTriggerResult {
   ok: boolean
@@ -175,6 +175,44 @@ export const tradingAgentsApi = {
   /** 读取本月预算 + 单次预估成本(用于触发前确认弹窗)。 */
   getBudget(): Promise<BudgetInfo> {
     return fetchAPI('/agents/tradingagents/budget')
+  },
+
+  /** 把某次深度分析报告导出为 PDF 文件并触发下载(后台直出,不走打印对话框)。 */
+  async downloadAnalysisPdf(symbol: string, date: string): Promise<void> {
+    const token = getToken()
+    const qs = new URLSearchParams({ stock_symbol: symbol, analysis_date: date })
+    const resp = await fetch(`/api/agents/tradingagents/analysis/pdf?${qs.toString()}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+    if (!resp.ok) {
+      let msg = `导出失败 (${resp.status})`
+      try {
+        const j = await resp.json()
+        msg = (j && (j.message || j.detail)) || msg
+      } catch {
+        /* 非 JSON 错误体,用默认提示 */
+      }
+      throw new Error(msg)
+    }
+    const blob = await resp.blob()
+    let filename = `深度分析-${date}.pdf`
+    const cd = resp.headers.get('Content-Disposition') || ''
+    const m = cd.match(/filename\*=UTF-8''([^;]+)/i)
+    if (m) {
+      try {
+        filename = decodeURIComponent(m[1])
+      } catch {
+        /* 保留默认文件名 */
+      }
+    }
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
   },
 
   /** 查某只股票最近 30 分钟有没有在跑或刚完成的 TA 任务(后端权威源)。

--- a/frontend/src/pages/AnalysisDetail.tsx
+++ b/frontend/src/pages/AnalysisDetail.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import {
   ArrowLeft,
+  FileDown,
   List,
   ChevronDown,
   Target,
@@ -112,6 +113,19 @@ export default function AnalysisDetailPage() {
       return true
     }
   })
+  const [pdfBusy, setPdfBusy] = useState(false)
+
+  const handleExportPdf = async () => {
+    if (pdfBusy) return
+    setPdfBusy(true)
+    try {
+      await tradingAgentsApi.downloadAnalysisPdf(symbol, date)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : '导出失败')
+    } finally {
+      setPdfBusy(false)
+    }
+  }
 
   useEffect(() => {
     setLoading(true)
@@ -262,6 +276,15 @@ export default function AnalysisDetailPage() {
             </button>
             <h1 className="text-base font-bold truncate min-w-0">{result.title || `${symbol} 深度分析`}</h1>
             <span className="text-[12px] text-muted-foreground shrink-0">{date}</span>
+            <button
+              onClick={handleExportPdf}
+              disabled={pdfBusy}
+              className="ml-auto shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/50 text-[12.5px] text-muted-foreground hover:text-foreground hover:bg-accent transition-all disabled:opacity-50"
+              title="导出 PDF 文件"
+            >
+              <FileDown className="w-3.5 h-3.5" />
+              {pdfBusy ? '导出中…' : '导出 PDF'}
+            </button>
           </div>
 
           {/* 正文 */}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ uvicorn>=0.24.0
 sqlalchemy>=2.0.0
 playwright==1.57.0
 PyJWT>=2.8.0
+# 详情报告导出 PDF(后台直出,不依赖 Chromium;会拉入 reportlab/pypdf 等)
+xhtml2pdf>=0.2.17
 
 # 深度分析 — TradingAgents (多 Agent 投资决策框架, 76k star)。
 # 不在 PyPI,用 git+ URL 安装。会拉 langchain/langgraph/yfinance 等较重依赖

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,10 @@ uvicorn>=0.24.0
 sqlalchemy>=2.0.0
 playwright==1.57.0
 PyJWT>=2.8.0
-# 详情报告导出 PDF(后台直出,不依赖 Chromium;会拉入 reportlab/pypdf 等)
+# 详情报告导出 PDF(后台直出,不依赖 Chromium):
+# 主引擎 WeasyPrint(HTML 保真排版,需系统库 pango/cairo + 中文字体,如 Docker 加 fonts-noto-cjk);
+# WeasyPrint 不可用时回退 xhtml2pdf(纯库保底,中文用 reportlab STSong-Light)。
+weasyprint>=60
 xhtml2pdf>=0.2.17
 
 # 深度分析 — TradingAgents (多 Agent 投资决策框架, 76k star)。

--- a/src/core/pdf_export.py
+++ b/src/core/pdf_export.py
@@ -1,8 +1,10 @@
-"""详情报告导出 PDF —— 纯后端生成,不依赖 Chromium。
+"""详情报告导出 PDF —— HTML 保真排版。
 
-markdown → HTML(python-markdown)→ PDF(xhtml2pdf / reportlab)。
-中文用 reportlab 内置 STSong-Light CID 字体,无需打包 TTF、无系统库依赖。
-(Chromium/page.pdf 可作为将来的高保真备选。)
+markdown → HTML(python-markdown)→ PDF。
+- 主引擎 **WeasyPrint**:真 CSS 排版引擎,自动换行/分页/页码,中文走系统字体,排版接近网页。
+- WeasyPrint 不可用(缺系统库 pango 等)时回退 **xhtml2pdf**(纯库、排版朴素但保底,
+  中文用 reportlab 内置 STSong-Light CID 字体)。
+(Chromium/page.pdf 可作为将来更高保真的备选,但需安装浏览器,这里不默认依赖。)
 """
 
 from __future__ import annotations
@@ -12,61 +14,99 @@ import logging
 from html import escape
 
 import markdown as _markdown
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.cidfonts import UnicodeCIDFont
-from xhtml2pdf import pisa
 
 logger = logging.getLogger(__name__)
 
-_CJK_FONT = "STSong-Light"  # reportlab 内置简体中文 CID 字体
-_font_ready = False
 
+# ---- WeasyPrint(主)----
 
-def _ensure_font() -> None:
-    global _font_ready
-    if not _font_ready:
-        pdfmetrics.registerFont(UnicodeCIDFont(_CJK_FONT))
-        _font_ready = True
-
-
-_CSS = """
-@page { size: A4; margin: 1.7cm 1.5cm; }
-body { font-family: STSong-Light; font-size: 10.5pt; line-height: 1.6; color: #1f2937; }
-.doc-title { font-size: 17pt; font-weight: bold; color: #111827;
-             border-bottom: 1.5pt solid #d1d5db; padding-bottom: 6pt; margin-bottom: 12pt; }
-h1 { font-size: 15pt; margin: 14pt 0 6pt; color: #111827; }
-h2 { font-size: 13pt; margin: 12pt 0 5pt; color: #1f2937; }
-h3 { font-size: 11.5pt; margin: 10pt 0 4pt; color: #374151; }
-p  { margin: 4pt 0; }
-ul, ol { margin: 4pt 0 4pt 6pt; }
-li { margin: 2pt 0; }
-strong, b { font-weight: bold; }
-table { border-collapse: collapse; width: 100%; margin: 6pt 0; }
-th, td { border: 0.5pt solid #d1d5db; padding: 4pt 6pt; font-size: 9.5pt; }
-th { background: #f3f4f6; }
-hr { border: none; border-top: 0.5pt solid #e5e7eb; margin: 10pt 0; }
-a { color: #2563eb; }
-.footer { margin-top: 16pt; padding-top: 6pt; border-top: 0.5pt solid #e5e7eb;
-          font-size: 8.5pt; color: #9ca3af; }
+_REPORT_CSS = """
+@page {
+  size: A4; margin: 1.7cm 1.5cm;
+  @bottom-center { content: "仅供参考,不构成投资建议 · 第 " counter(page) " / " counter(pages) " 页";
+                   font-size: 8pt; color: #9ca3af; }
+}
+body { font-family: "PingFang SC", "Noto Sans CJK SC", "Microsoft YaHei", "Hiragino Sans GB", sans-serif;
+       font-size: 10.5pt; line-height: 1.75; color: #1f2937; }
+.doc-title { font-size: 18pt; font-weight: 700; color: #0f172a;
+             border-bottom: 2pt solid #e11d48; padding-bottom: 8pt; margin: 0 0 14pt; }
+h1 { font-size: 14.5pt; color: #0f172a; margin: 16pt 0 6pt; padding-left: 8pt;
+     border-left: 3pt solid #2563eb; page-break-after: avoid; }
+h2 { font-size: 12.5pt; color: #1e293b; margin: 13pt 0 5pt; page-break-after: avoid; }
+h3 { font-size: 11.5pt; color: #334155; margin: 10pt 0 4pt; page-break-after: avoid; }
+p { margin: 5pt 0; }
+ul, ol { margin: 5pt 0 5pt 16pt; }
+li { margin: 2.5pt 0; }
+strong, b { font-weight: 700; color: #0f172a; }
+table { border-collapse: collapse; width: 100%; margin: 8pt 0; }
+th, td { border: 0.5pt solid #d1d5db; padding: 5pt 8pt; font-size: 9.5pt; text-align: left;
+         vertical-align: top; }
+th { background: #f1f5f9; font-weight: 600; }
+hr { border: none; border-top: 0.5pt solid #e5e7eb; margin: 12pt 0; }
+blockquote { border-left: 3pt solid #cbd5e1; margin: 6pt 0; padding: 2pt 0 2pt 10pt; color: #475569; }
+code { background: #f1f5f9; padding: 1pt 3pt; border-radius: 2pt; }
+a { color: #2563eb; text-decoration: none; }
 """
 
 
-def render_analysis_pdf(title: str, markdown_text: str) -> bytes:
-    """把分析报告 markdown 渲染成 PDF 字节(中文矢量、可复制、可选中)。"""
-    _ensure_font()
-    body_html = _markdown.markdown(
-        markdown_text or "",
-        extensions=["tables", "fenced_code", "sane_lists"],
+def _md_to_html(markdown_text: str) -> str:
+    return _markdown.markdown(
+        markdown_text or "", extensions=["tables", "fenced_code", "sane_lists"]
     )
+
+
+def _render_weasyprint(title: str, body_html: str) -> bytes:
+    from weasyprint import HTML
+
     doc = (
-        '<html><head><meta charset="utf-8"><style>' + _CSS + "</style></head><body>"
+        '<html><head><meta charset="utf-8"><style>' + _REPORT_CSS + "</style></head><body>"
         + f'<div class="doc-title">{escape((title or "深度分析").strip())}</div>'
         + body_html
-        + '<div class="footer">本报告由 AI 生成,仅供参考,不构成投资建议。</div>'
         + "</body></html>"
     )
+    return HTML(string=doc).write_pdf()
+
+
+# ---- xhtml2pdf(回退,纯库无系统依赖)----
+
+_FALLBACK_CSS = """
+@page { size: A4; margin: 1.6cm 1.5cm; }
+body { font-family: STSong-Light; font-size: 10.5pt; line-height: 1.6; color: #1f2937; }
+.doc-title { font-size: 16pt; font-weight: bold; border-bottom: 1.5pt solid #d1d5db;
+             padding-bottom: 6pt; margin-bottom: 12pt; }
+h1 { font-size: 14pt; margin: 12pt 0 5pt; } h2 { font-size: 12pt; margin: 10pt 0 4pt; }
+h3 { font-size: 11pt; margin: 8pt 0 3pt; } p { margin: 4pt 0; }
+ul, ol { margin: 4pt 0 4pt 6pt; } li { margin: 2pt 0; }
+table { border-collapse: collapse; width: 100%; } th, td { border: 0.5pt solid #d1d5db; padding: 4pt 6pt; }
+"""
+
+
+def _render_xhtml2pdf(title: str, body_html: str) -> bytes:
+    from reportlab.pdfbase import pdfmetrics
+    from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+    from xhtml2pdf import pisa
+
+    try:
+        pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+    except Exception:
+        pass
+    doc = (
+        '<html><head><meta charset="utf-8"><style>' + _FALLBACK_CSS + "</style></head><body>"
+        + f'<div class="doc-title">{escape((title or "深度分析").strip())}</div>'
+        + body_html
+        + '<div style="margin-top:14pt;font-size:8.5pt;color:#9ca3af;">'
+        + "本报告由 AI 生成,仅供参考,不构成投资建议。</div></body></html>"
+    )
     buf = io.BytesIO()
-    result = pisa.CreatePDF(src=doc, dest=buf, encoding="utf-8")
-    if result.err:
-        logger.warning("[PDF导出] 渲染存在告警/错误: err=%s", result.err)
+    pisa.CreatePDF(src=doc, dest=buf, encoding="utf-8")
     return buf.getvalue()
+
+
+def render_analysis_pdf(title: str, markdown_text: str) -> bytes:
+    """分析报告 markdown → PDF 字节(中文矢量、可复制)。WeasyPrint 优先,失败回退 xhtml2pdf。"""
+    body_html = _md_to_html(markdown_text)
+    try:
+        return _render_weasyprint(title, body_html)
+    except Exception as e:  # WeasyPrint 缺系统库/渲染异常 → 保底
+        logger.warning("[PDF导出] WeasyPrint 不可用,回退 xhtml2pdf: %s", e)
+        return _render_xhtml2pdf(title, body_html)

--- a/src/core/pdf_export.py
+++ b/src/core/pdf_export.py
@@ -102,6 +102,69 @@ def _render_xhtml2pdf(title: str, body_html: str) -> bytes:
     return buf.getvalue()
 
 
+_ANALYST_SECTIONS = [
+    ("market", "技术分析师"),
+    ("social", "情绪分析师"),
+    ("news", "新闻分析师"),
+    ("fundamentals", "基本面分析师"),
+]
+
+
+def assemble_report_markdown(raw_data: dict) -> str:
+    """从 raw_data 拼出与详情页(buildAnalysisSections)同款分节的完整报告 markdown。
+
+    顺序对齐详情页:决策摘要 → PM 决策书(+交易员)→ 4 分析师全文 → 看多看空辩论全文(+研究主管裁决)
+    → 风控辩论全文(+风控裁决)。比 `content` 字段更全(content 省略了 4 分析师与辩论全文)。
+    """
+    rd = raw_data or {}
+    sug = rd.get("suggestion") or {}
+    reports = rd.get("analyst_reports") or {}
+    debate = rd.get("debate_history") or {}
+    risk = rd.get("risk_debate") or {}
+    parts: list[str] = []
+
+    label = sug.get("action_label") or "持有"
+    head = f"**{label}**"
+    conf = sug.get("confidence")
+    if conf is not None:
+        try:
+            head += f" · 置信度 {float(conf):.1f}/10"
+        except (TypeError, ValueError):
+            pass
+    parts.append(f"## 最终决策\n\n{head}\n")
+
+    final_decision = (rd.get("final_decision") or "").strip()
+    trader = (rd.get("trader_plan") or "").strip()
+    if final_decision or trader:
+        body = final_decision
+        if trader:
+            body = (body + "\n\n" if body else "") + f"### 💼 交易员执行计划\n\n{trader}"
+        parts.append(f"## PM 最终决策书\n\n{body}\n")
+
+    for key, title in _ANALYST_SECTIONS:
+        txt = (reports.get(key) or "").strip()
+        if txt:
+            parts.append(f"## {title}\n\n{txt}\n")
+
+    dh = (debate.get("history") or "").strip()
+    if dh:
+        seg = dh
+        jd = (debate.get("judge_decision") or "").strip()
+        if jd:
+            seg += f"\n\n### ⚖️ 研究主管裁决\n\n{jd}"
+        parts.append(f"## 看多看空辩论\n\n{seg}\n")
+
+    rh = (risk.get("history") or "").strip()
+    rjd = (rd.get("risk_judgment") or risk.get("judge_decision") or "").strip()
+    if rh or rjd:
+        seg = rh
+        if rjd:
+            seg += (("\n\n" if seg else "") + f"### 🛡️ 风控裁决\n\n{rjd}")
+        parts.append(f"## 风控辩论\n\n{seg}\n")
+
+    return "\n".join(parts).strip()
+
+
 def render_analysis_pdf(title: str, markdown_text: str) -> bytes:
     """分析报告 markdown → PDF 字节(中文矢量、可复制)。WeasyPrint 优先,失败回退 xhtml2pdf。"""
     body_html = _md_to_html(markdown_text)

--- a/src/core/pdf_export.py
+++ b/src/core/pdf_export.py
@@ -1,0 +1,72 @@
+"""详情报告导出 PDF —— 纯后端生成,不依赖 Chromium。
+
+markdown → HTML(python-markdown)→ PDF(xhtml2pdf / reportlab)。
+中文用 reportlab 内置 STSong-Light CID 字体,无需打包 TTF、无系统库依赖。
+(Chromium/page.pdf 可作为将来的高保真备选。)
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from html import escape
+
+import markdown as _markdown
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+from xhtml2pdf import pisa
+
+logger = logging.getLogger(__name__)
+
+_CJK_FONT = "STSong-Light"  # reportlab 内置简体中文 CID 字体
+_font_ready = False
+
+
+def _ensure_font() -> None:
+    global _font_ready
+    if not _font_ready:
+        pdfmetrics.registerFont(UnicodeCIDFont(_CJK_FONT))
+        _font_ready = True
+
+
+_CSS = """
+@page { size: A4; margin: 1.7cm 1.5cm; }
+body { font-family: STSong-Light; font-size: 10.5pt; line-height: 1.6; color: #1f2937; }
+.doc-title { font-size: 17pt; font-weight: bold; color: #111827;
+             border-bottom: 1.5pt solid #d1d5db; padding-bottom: 6pt; margin-bottom: 12pt; }
+h1 { font-size: 15pt; margin: 14pt 0 6pt; color: #111827; }
+h2 { font-size: 13pt; margin: 12pt 0 5pt; color: #1f2937; }
+h3 { font-size: 11.5pt; margin: 10pt 0 4pt; color: #374151; }
+p  { margin: 4pt 0; }
+ul, ol { margin: 4pt 0 4pt 6pt; }
+li { margin: 2pt 0; }
+strong, b { font-weight: bold; }
+table { border-collapse: collapse; width: 100%; margin: 6pt 0; }
+th, td { border: 0.5pt solid #d1d5db; padding: 4pt 6pt; font-size: 9.5pt; }
+th { background: #f3f4f6; }
+hr { border: none; border-top: 0.5pt solid #e5e7eb; margin: 10pt 0; }
+a { color: #2563eb; }
+.footer { margin-top: 16pt; padding-top: 6pt; border-top: 0.5pt solid #e5e7eb;
+          font-size: 8.5pt; color: #9ca3af; }
+"""
+
+
+def render_analysis_pdf(title: str, markdown_text: str) -> bytes:
+    """把分析报告 markdown 渲染成 PDF 字节(中文矢量、可复制、可选中)。"""
+    _ensure_font()
+    body_html = _markdown.markdown(
+        markdown_text or "",
+        extensions=["tables", "fenced_code", "sane_lists"],
+    )
+    doc = (
+        '<html><head><meta charset="utf-8"><style>' + _CSS + "</style></head><body>"
+        + f'<div class="doc-title">{escape((title or "深度分析").strip())}</div>'
+        + body_html
+        + '<div class="footer">本报告由 AI 生成,仅供参考,不构成投资建议。</div>'
+        + "</body></html>"
+    )
+    buf = io.BytesIO()
+    result = pisa.CreatePDF(src=doc, dest=buf, encoding="utf-8")
+    if result.err:
+        logger.warning("[PDF导出] 渲染存在告警/错误: err=%s", result.err)
+    return buf.getvalue()

--- a/src/web/api/agents.py
+++ b/src/web/api/agents.py
@@ -574,6 +574,47 @@ def get_tradingagents_analysis(
     }
 
 
+@router.get("/tradingagents/analysis/pdf")
+def export_tradingagents_analysis_pdf(
+    stock_symbol: str = Query(..., description="股票代码"),
+    analysis_date: str = Query(..., description="分析日期 YYYY-MM-DD"),
+    db: Session = Depends(get_db),
+):
+    """把某次 TradingAgents 深度分析报告导出为 PDF 文件(后台直出,不依赖 Chromium)。
+
+    返回 application/pdf(ResponseWrapperMiddleware 对非 JSON 原样放行,不会包裹)。
+    """
+    from urllib.parse import quote
+
+    from fastapi import HTTPException
+    from fastapi.responses import Response
+
+    from src.core.pdf_export import render_analysis_pdf
+    from src.web.models import AnalysisHistory
+
+    record = (
+        db.query(AnalysisHistory)
+        .filter(
+            AnalysisHistory.agent_name == "tradingagents",
+            AnalysisHistory.stock_symbol == stock_symbol,
+            AnalysisHistory.analysis_date == analysis_date,
+        )
+        .order_by(AnalysisHistory.updated_at.desc(), AnalysisHistory.id.desc())
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="未找到该深度分析记录")
+
+    pdf_bytes = render_analysis_pdf(record.title or "深度分析", record.content or "")
+    base = (record.title or f"{stock_symbol} 深度分析").replace("/", "-").replace("\\", "-").strip()
+    filename = f"{base}-{analysis_date}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}"},
+    )
+
+
 @router.get("/tradingagents/history-comparison")
 def get_tradingagents_history_comparison(
     stock_symbol: str = Query(..., description="股票代码,如 300418"),

--- a/src/web/api/agents.py
+++ b/src/web/api/agents.py
@@ -589,7 +589,7 @@ def export_tradingagents_analysis_pdf(
     from fastapi import HTTPException
     from fastapi.responses import Response
 
-    from src.core.pdf_export import render_analysis_pdf
+    from src.core.pdf_export import assemble_report_markdown, render_analysis_pdf
     from src.web.models import AnalysisHistory
 
     record = (
@@ -605,7 +605,9 @@ def export_tradingagents_analysis_pdf(
     if not record:
         raise HTTPException(status_code=404, detail="未找到该深度分析记录")
 
-    pdf_bytes = render_analysis_pdf(record.title or "深度分析", record.content or "")
+    # 用 raw_data 拼详情页同款完整分节(含 4 分析师全文 + 辩论全文);raw_data 缺失时回退 content
+    report_md = assemble_report_markdown(record.raw_data or {}) or (record.content or "")
+    pdf_bytes = render_analysis_pdf(record.title or "深度分析", report_md)
     base = (record.title or f"{stock_symbol} 深度分析").replace("/", "-").replace("\\", "-").strip()
     filename = f"{base}-{analysis_date}.pdf"
     return Response(

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -30,6 +30,32 @@ def test_render_pdf_handles_empty_markdown():
     assert bytes(data[:4]) == b"%PDF"
 
 
+def test_assemble_report_markdown_mirrors_detail_page_sections():
+    """从 raw_data 拼出的报告含详情页全部分节:PM/交易员/4分析师全文/多空辩论全文/风控辩论全文。"""
+    from src.core.pdf_export import assemble_report_markdown
+
+    raw = {
+        "suggestion": {"action_label": "持有", "confidence": 5.0},
+        "final_decision": "PM决策正文XYZ",
+        "trader_plan": "交易员计划正文XYZ",
+        "analyst_reports": {
+            "market": "技术面分析正文XYZ", "social": "情绪面分析正文XYZ",
+            "news": "新闻面分析正文XYZ", "fundamentals": "基本面分析正文XYZ",
+        },
+        "debate_history": {"history": "多头观点AAA 空头观点BBB", "judge_decision": "研究主管裁决XYZ"},
+        "risk_debate": {"history": "激进CCC 保守DDD", "judge_decision": "风控裁决XYZ"},
+    }
+    md = assemble_report_markdown(raw)
+    for must in [
+        "PM决策正文XYZ", "交易员计划正文XYZ",
+        "技术面分析正文XYZ", "情绪面分析正文XYZ", "新闻面分析正文XYZ", "基本面分析正文XYZ",
+        "多头观点AAA", "空头观点BBB", "研究主管裁决XYZ",
+        "激进CCC", "风控裁决XYZ",
+        "技术分析师", "看多看空辩论", "风控辩论",
+    ]:
+        assert must in md, f"缺少: {must}"
+
+
 def _mem_db():
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
@@ -42,8 +68,8 @@ def _mem_db():
     return sessionmaker(bind=engine)()
 
 
-def test_pdf_endpoint_returns_pdf_for_existing_record():
-    """端点:存在记录 → 返回 application/pdf 附件文件。"""
+def test_pdf_endpoint_returns_full_detail_content():
+    """端点:返回 application/pdf 附件,且含详情页完整内容(分析师/辩论全文,来自 raw_data,非仅 content 摘要)。"""
     from src.web.api import agents
     from src.web.models import AnalysisHistory
 
@@ -52,7 +78,14 @@ def test_pdf_endpoint_returns_pdf_for_existing_record():
         db.add(AnalysisHistory(
             agent_name="tradingagents", stock_symbol="601238",
             analysis_date="2026-06-20", title="【深度】广汽集团(601238):持有",
-            content="# 广汽集团深度分析\n\n**持有** 置信度 5/10",
+            content="# 摘要\n\n**持有**",  # content 是精简版,不含下面这些
+            raw_data={
+                "suggestion": {"action_label": "持有", "confidence": 5.0},
+                "final_decision": "PM决策正文",
+                "analyst_reports": {"market": "技术面分析正文UNIQUE", "fundamentals": "基本面正文"},
+                "debate_history": {"history": "多头观点UNIQUE 空头观点", "judge_decision": "研究主管裁决"},
+                "risk_debate": {"history": "激进 保守", "judge_decision": "风控裁决"},
+            },
         ))
         db.commit()
         resp = agents.export_tradingagents_analysis_pdf(
@@ -60,6 +93,14 @@ def test_pdf_endpoint_returns_pdf_for_existing_record():
         assert resp.media_type == "application/pdf"
         assert bytes(resp.body[:4]) == b"%PDF"
         assert "attachment" in resp.headers["content-disposition"]
+
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(bytes(resp.body)))
+        txt = "\n".join((p.extract_text() or "") for p in reader.pages)
+        # content 摘要里没有的「分析师全文 / 辩论全文」确实进了 PDF
+        assert "技术面分析正文UNIQUE" in txt
+        assert "多头观点UNIQUE" in txt
     finally:
         db.close()
 

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,0 +1,81 @@
+"""详情报告导出 PDF(后台直出:xhtml2pdf + reportlab STSong-Light 中文字体)。"""
+
+from __future__ import annotations
+
+import io
+
+
+def test_render_pdf_returns_valid_bytes_with_chinese():
+    """markdown→PDF:返回合法 PDF 字节,且中文进入文本层(非豆腐块、可复制)。"""
+    from src.core.pdf_export import render_analysis_pdf
+
+    md = "# 广汽集团(601238)深度分析\n\n**最终决策:持有**\n\n- 多头:业绩拐点确认\n- 空头:估值偏高"
+    data = render_analysis_pdf("【深度】广汽集团(601238):持有", md)
+    assert isinstance(data, (bytes, bytearray))
+    assert bytes(data[:4]) == b"%PDF"
+    assert len(data) > 1500
+
+    from pypdf import PdfReader
+
+    txt = PdfReader(io.BytesIO(bytes(data))).pages[0].extract_text() or ""
+    assert "广汽集团" in txt
+    assert "持有" in txt
+
+
+def test_render_pdf_handles_empty_markdown():
+    """空正文也不崩,仍返回合法 PDF(至少有标题)。"""
+    from src.core.pdf_export import render_analysis_pdf
+
+    data = render_analysis_pdf("标题", "")
+    assert bytes(data[:4]) == b"%PDF"
+
+
+def _mem_db():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    import src.web.models  # noqa: F401
+    from src.web.database import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_pdf_endpoint_returns_pdf_for_existing_record():
+    """端点:存在记录 → 返回 application/pdf 附件文件。"""
+    from src.web.api import agents
+    from src.web.models import AnalysisHistory
+
+    db = _mem_db()
+    try:
+        db.add(AnalysisHistory(
+            agent_name="tradingagents", stock_symbol="601238",
+            analysis_date="2026-06-20", title="【深度】广汽集团(601238):持有",
+            content="# 广汽集团深度分析\n\n**持有** 置信度 5/10",
+        ))
+        db.commit()
+        resp = agents.export_tradingagents_analysis_pdf(
+            stock_symbol="601238", analysis_date="2026-06-20", db=db)
+        assert resp.media_type == "application/pdf"
+        assert bytes(resp.body[:4]) == b"%PDF"
+        assert "attachment" in resp.headers["content-disposition"]
+    finally:
+        db.close()
+
+
+def test_pdf_endpoint_404_when_missing():
+    """端点:无记录 → HTTP 404。"""
+    import pytest
+    from fastapi import HTTPException
+
+    from src.web.api import agents
+
+    db = _mem_db()
+    try:
+        with pytest.raises(HTTPException) as ei:
+            agents.export_tradingagents_analysis_pdf(
+                stock_symbol="000000", analysis_date="2026-06-20", db=db)
+        assert ei.value.status_code == 404
+    finally:
+        db.close()


### PR DESCRIPTION
## 详情报告导出 PDF(后台直出文件)

详情页深度分析报告一键导出为 PDF 文件,不走浏览器打印对话框。

### 实现
- **后台直出文件**:`GET /api/agents/tradingagents/analysis/pdf` 返回 `application/pdf` 附件;前端「导出PDF」按钮带 JWT 拉 blob 直接下载(中间件对非 JSON 放行)。
- **HTML 保真排版**:WeasyPrint 主引擎(真 CSS、自动换行/分页/页码、中文走系统字体);WeasyPrint 不可用时回退 xhtml2pdf(纯库保底,reportlab STSong-Light)。修掉了 xhtml2pdf 的丑 + 右侧裁切。
- **完整内容**:按详情页 `buildAnalysisSections` 同款分节从 `raw_data` 拼(PM 决策书+交易员 → 4 分析师全文 → 看多看空辩论全文+研究主管裁决 → 风控辩论全文+风控裁决),而非精简的 `content` 字段。

### 测试
- 后端 **384 passed, 1 skipped**;新增 5 个 PDF 单测(中文进文本层 / 端点 / 404 / 完整分节 / 端点端到端含分析师&辩论全文)。

### 部署注意
Docker 镜像需装 `pango/cairo` + 中文字体(`fonts-noto-cjk`),否则容器内 WeasyPrint 回退或中文豆腐。已在 requirements 注释标明。