### PR TITLE
feat(health): 自检二期(DB/磁盘/调度 + make doctor + 数据源降级提醒)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup-backend dev-api dev-web build test test-notify install-hooks clean-venv
+.PHONY: help setup-backend dev-api dev-web build test test-notify doctor install-hooks clean-venv
 
 # 端口约定：
 #   - 后端：:8000（Docker / 本地 dev 统一，避免存量用户升级困惑）
@@ -11,6 +11,7 @@ help:
 	@echo "  make dev-web         启动前端（:5183，自动 pnpm install）"
 	@echo "  make test            跑全部单测（默认不发通知）"
 	@echo "  make test-notify     跑全部单测（实际发送通知）"
+	@echo "  make doctor          系统自检(数据源/AI/通知/DB/磁盘/调度)"
 	@echo "  make build VERSION=x 构建前端 + Docker 镜像"
 	@echo "  make install-hooks   安装 git pre-push hook"
 	@echo "  make clean-venv      删除本地 venv"
@@ -39,6 +40,10 @@ test:
 
 test-notify:
 	. .venv/bin/activate && python -m pytest tests/ -v --notify
+
+# 命令行系统自检:跑一遍数据源/AI/通知 + DB/磁盘/调度,打印结果与修复建议
+doctor:
+	. .venv/bin/activate && python -m src.core.doctor
 
 # 用法: make build VERSION=0.3.0
 build:

--- a/frontend/src/components/SelfCheckModal.tsx
+++ b/frontend/src/components/SelfCheckModal.tsx
@@ -31,11 +31,12 @@ interface CheckRow {
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
+  system: '系统',
   datasource: '数据源',
   ai: 'AI模型',
   notify: '通知渠道',
 }
-const CATEGORY_ORDER = ['datasource', 'ai', 'notify']
+const CATEGORY_ORDER = ['system', 'datasource', 'ai', 'notify']
 const CONCURRENCY = 4
 
 const STATUS_META: Record<RowStatus, {

--- a/src/core/context_scheduler.py
+++ b/src/core/context_scheduler.py
@@ -119,6 +119,16 @@ class ContextMaintenanceScheduler:
                 )
             except Exception as fc_err:
                 logger.debug("[上下文维护] 因子自校准跳过: %s", fc_err)
+
+            # 系统自检 + 数据源降级提醒(数据源/基础项 断则去重通知;自动降级已由 priority 主备承担)
+            try:
+                from src.core.selfcheck import selfcheck_and_notify
+
+                sc = await selfcheck_and_notify()
+                if sc.get("notified"):
+                    logger.warning("[上下文维护] 系统自检发现 %s 项异常,已通知", sc.get("failed"))
+            except Exception as sc_err:
+                logger.debug("[上下文维护] 系统自检跳过: %s", sc_err)
         except Exception as e:
             logger.exception(f"[上下文维护] 后验评估异常: {e}")
         finally:
@@ -280,6 +290,8 @@ class ContextMaintenanceScheduler:
             max_instances=1,
         )
         self.scheduler.start()
+        from src.core.scheduler_registry import register
+        register("context", self.scheduler)
         logger.info(
             "上下文维护调度器已启动（后验评估间隔 %sh，启动补跑 +15s，快照保留 %s 天，后验保留 %s 天，机会自动刷新 01:15/05:30/14:00 UTC）",
             self.eval_interval_hours,

--- a/src/core/doctor.py
+++ b/src/core/doctor.py
@@ -1,0 +1,56 @@
+"""命令行系统自检:`python -m src.core.doctor` 或 `make doctor`。
+
+终端跑一遍 系统基础项(DB/磁盘/调度)+ 数据源/AI/通知,打印结果与中文修复建议。
+CLI 进程内无运行中的调度器 → 调度项会优雅跳过(显示说明,不误报)。
+退出码:有异常项返回 1,全通返回 0(便于 CI/脚本判断)。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from src.core.selfcheck import run_selfcheck
+
+_ICON = {"ok": "✅", "slow": "⚠️", "fail": "❌"}
+_CAT = {"system": "系统", "datasource": "数据源", "ai": "AI模型", "notify": "通知渠道"}
+_ORDER = ["system", "datasource", "ai", "notify"]
+
+
+def _print_report(res: dict) -> None:
+    s = res["summary"]
+    print("\n===== PanWatch 系统自检 =====")
+    print(f"共 {s['total']} · ✅通 {s['ok']} · ⚠️慢 {s['slow']} · ❌断 {s['fail']}\n")
+    items = res.get("items", [])
+    for cat in _ORDER:
+        cat_items = [i for i in items if i["category"] == cat]
+        if not cat_items:
+            continue
+        print(f"【{_CAT.get(cat, cat)}】")
+        for i in cat_items:
+            icon = _ICON.get(i["status"], "?")
+            grp = f"{i['group']} / " if i.get("group") else ""
+            lat = f"  {i['latency_ms']}ms" if i.get("latency_ms") else ""
+            print(f"  {icon} {grp}{i['name']}{lat}")
+            if i["status"] == "fail":
+                if i.get("error"):
+                    print(f"       错误: {i['error']}")
+                if i.get("hint"):
+                    print(f"       建议: {i['hint']}")
+            elif i.get("note"):
+                print(f"       {i['note']}")
+        print()
+    if s["fail"]:
+        print(f"⚠️  发现 {s['fail']} 项异常,见上方建议。")
+    else:
+        print("✅ 全部正常。")
+
+
+def main() -> int:
+    res = asyncio.run(run_selfcheck())
+    _print_report(res)
+    return 1 if res["summary"]["fail"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/paper_trading_scheduler.py
+++ b/src/core/paper_trading_scheduler.py
@@ -104,6 +104,8 @@ class PaperTradingScheduler:
             max_instances=1,
         )
         self.scheduler.start()
+        from src.core.scheduler_registry import register
+        register("paper_trading", self.scheduler)
         logger.info(f"模拟盘调度器已启动，扫描间隔 {self.interval_seconds}s")
 
     def shutdown(self):

--- a/src/core/price_alert_scheduler.py
+++ b/src/core/price_alert_scheduler.py
@@ -57,6 +57,8 @@ class PriceAlertScheduler:
             max_instances=1,
         )
         self.scheduler.start()
+        from src.core.scheduler_registry import register
+        register("price_alert", self.scheduler)
         logger.info(f"价格提醒调度器已启动，扫描间隔 {self.interval_seconds}s")
 
     def shutdown(self):

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -178,6 +178,8 @@ class AgentScheduler:
     def start(self):
         """启动调度器"""
         self.scheduler.start()
+        from src.core.scheduler_registry import register
+        register("agent", self.scheduler)
         logger.info(f"调度器已启动，已注册 {len(self.agents)} 个 Agent")
 
         # 打印所有已注册的任务

--- a/src/core/scheduler_registry.py
+++ b/src/core/scheduler_registry.py
@@ -1,0 +1,21 @@
+"""运行中调度器的轻量注册表,供系统自检读取健康状态。
+
+各调度器 start() 时把自身的 APScheduler(有 .running / .get_jobs())register 进来;
+自检的 probe_scheduler 据此判断"调度器是否在跑"。CLI 等无调度的进程注册表为空 → 优雅跳过。
+"""
+
+from __future__ import annotations
+
+_REGISTRY: dict[str, object] = {}
+
+
+def register(name: str, scheduler: object) -> None:
+    _REGISTRY[name] = scheduler
+
+
+def get_all() -> dict[str, object]:
+    return dict(_REGISTRY)
+
+
+def clear() -> None:
+    _REGISTRY.clear()

--- a/src/core/selfcheck.py
+++ b/src/core/selfcheck.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import time
 
+from src.core.notify_dedupe import check_and_mark_notify
 from src.web.database import SessionLocal
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,14 @@ def classify_hint(category: str, error: str | None) -> str:
         if any(k in e for k in ("forbidden", "unauthorized", "403", "401", "404", "blocked", "connect", "timeout")):
             return "通知发送失败:检查 webhook 地址/token 是否正确、是否被网络拦截。"
         return "通知不通:核对渠道配置,或到渠道页点「测试」做真实发送验证。"
+    if category == "system":
+        if "lock" in e:
+            return "SQLite 被锁:并发调度叠加慢代理所致,降低并发或加快/关闭代理。"
+        if any(k in e for k in ("disk", "space", "磁盘", "空间")):
+            return "磁盘空间不足:清理 data 目录旧数据/日志,或扩容磁盘。"
+        if any(k in e for k in ("scheduler", "调度", "stopped", "not running")):
+            return "调度器未运行/已停止:重启服务以恢复定时任务。"
+        return error or "系统项异常,查看日志。"
     return error or "未知错误,查看日志。"
 
 
@@ -128,6 +137,78 @@ async def probe_notify_channel(channel, *, send: bool = False) -> dict:
                      int((time.monotonic() - t0) * 1000), str(e))
 
 
+async def probe_db() -> dict:
+    """对真实库执行 SELECT 1。"""
+    from sqlalchemy import text
+
+    from src.web.database import SessionLocal
+
+    t0 = time.monotonic()
+    try:
+        db = SessionLocal()
+        try:
+            db.execute(text("SELECT 1"))
+        finally:
+            db.close()
+        latency = int((time.monotonic() - t0) * 1000)
+        return _item("system", "sys:db", "数据库", _status_for(True, latency), latency)
+    except Exception as e:
+        return _item("system", "sys:db", "数据库", "fail", int((time.monotonic() - t0) * 1000), str(e))
+
+
+async def probe_disk() -> dict:
+    """检查 data 目录所在盘的可用空间。"""
+    import os
+    import shutil
+
+    from src.web.database import DB_PATH
+
+    t0 = time.monotonic()
+    try:
+        data_dir = os.path.dirname(os.path.abspath(DB_PATH))
+        usage = shutil.disk_usage(data_dir)
+        free_gb = usage.free / (1024 ** 3)
+        total_gb = usage.total / (1024 ** 3)
+        note = f"可用 {free_gb:.1f}GB / 共 {total_gb:.1f}GB"
+        latency = int((time.monotonic() - t0) * 1000)
+        if free_gb < 0.2:
+            return _item("system", "sys:disk", "磁盘空间", "fail", latency,
+                         error=f"磁盘空间严重不足({note})", note=note)
+        status = "slow" if free_gb < 1.0 else "ok"
+        return _item("system", "sys:disk", "磁盘空间", status, latency, note=note)
+    except Exception as e:
+        return _item("system", "sys:disk", "磁盘空间", "fail", int((time.monotonic() - t0) * 1000), str(e))
+
+
+async def probe_scheduler() -> dict:
+    """经 scheduler_registry 看运行中的调度器;注册表空(CLI/未启动)→ 优雅跳过。"""
+    from src.core import scheduler_registry
+
+    regs = scheduler_registry.get_all()
+    if not regs:
+        return _item("system", "sys:scheduler", "调度器", "ok", 0,
+                     note="当前进程无运行中的调度器(CLI 自检会跳过此项)")
+    running: list[str] = []
+    stopped: list[str] = []
+    jobs = 0
+    for name, sched in regs.items():
+        try:
+            if getattr(sched, "running", False):
+                running.append(name)
+                jobs += len(sched.get_jobs())
+            else:
+                stopped.append(name)
+        except Exception:
+            stopped.append(name)
+    if running:
+        note = f"{len(running)} 个调度器运行中,共 {jobs} 个任务"
+        if stopped:
+            note += f";已停止: {', '.join(stopped)}"
+        return _item("system", "sys:scheduler", "调度器", "ok", 0, note=note)
+    return _item("system", "sys:scheduler", "调度器", "fail", 0,
+                 error=f"调度器已停止: {', '.join(stopped)}")
+
+
 async def _guard(coro, fallback: dict) -> dict:
     """给每个 probe 套超时;探测自身已 try/except,这里只兜超时/异常。"""
     try:
@@ -140,11 +221,15 @@ async def _guard(coro, fallback: dict) -> dict:
                      "fail", 0, str(e))
 
 
-def _enumerate(db) -> list[dict]:
-    """枚举所有启用的待检项(身份 + ORM 引用),不探测。"""
+def _enumerate(db, include_system: bool = True) -> list[dict]:
+    """枚举所有待检项(身份 + ORM 引用),不探测。include_system 加 DB/磁盘/调度 系统基础项。"""
     from src.web.models import AIModel, AIService, DataSource, NotifyChannel
 
     targets: list[dict] = []
+    if include_system:
+        targets.append({"category": "system", "key": "sys:db", "name": "数据库", "group": None, "_kind": "db"})
+        targets.append({"category": "system", "key": "sys:disk", "name": "磁盘空间", "group": None, "_kind": "disk"})
+        targets.append({"category": "system", "key": "sys:scheduler", "name": "调度器", "group": None, "_kind": "sched"})
     for src in db.query(DataSource).filter(DataSource.enabled.is_(True)).all():
         targets.append({"category": "datasource", "key": f"ds:{src.id}", "name": src.name,
                         "group": None, "_kind": "ds", "_obj": src})
@@ -166,31 +251,38 @@ def _identity(t: dict) -> dict:
 
 
 def _probe_for(t: dict, notify_send: bool):
-    if t["_kind"] == "ds":
+    kind = t["_kind"]
+    if kind == "db":
+        return probe_db()
+    if kind == "disk":
+        return probe_disk()
+    if kind == "sched":
+        return probe_scheduler()
+    if kind == "ds":
         return probe_datasource(t["_obj"])
-    if t["_kind"] == "ai":
+    if kind == "ai":
         return probe_ai_model(t["_obj"], t["_service"])
     return probe_notify_channel(t["_obj"], send=notify_send)
 
 
-def list_selfcheck_items(*, db=None) -> list[dict]:
-    """只枚举待检项身份(category/key/name),不探测;供前端先渲染列表再逐项检查。"""
+def list_selfcheck_items(*, db=None, include_system: bool = True) -> list[dict]:
+    """只枚举待检项身份(category/key/name/group),不探测;供前端先渲染列表再逐项检查。"""
     own = db is None
     db = db or SessionLocal()
     try:
-        return [_identity(t) for t in _enumerate(db)]
+        return [_identity(t) for t in _enumerate(db, include_system)]
     finally:
         if own:
             db.close()
 
 
-async def run_selfcheck(*, db=None, notify_send: bool = False, keys=None) -> dict:
-    """探测启用项,返回看板。keys 非空时只探测这些 key(供前端逐项更新进度)。"""
+async def run_selfcheck(*, db=None, notify_send: bool = False, keys=None, include_system: bool = True) -> dict:
+    """探测待检项,返回看板。keys 非空时只探测这些 key(供前端逐项更新进度)。"""
     own = db is None
     db = db or SessionLocal()
     try:
         keyset = set(keys) if keys is not None else None
-        targets = [t for t in _enumerate(db) if keyset is None or t["key"] in keyset]
+        targets = [t for t in _enumerate(db, include_system) if keyset is None or t["key"] in keyset]
         tasks = [_guard(_probe_for(t, notify_send), _identity(t)) for t in targets]
         items = list(await asyncio.gather(*tasks)) if tasks else []
         summary = {
@@ -200,6 +292,65 @@ async def run_selfcheck(*, db=None, notify_send: bool = False, keys=None) -> dic
             "fail": sum(1 for i in items if i["status"] == "fail"),
         }
         return {"items": items, "summary": summary, "notify_send": bool(notify_send)}
+    finally:
+        if own:
+            db.close()
+
+
+def _notifier_from_db(db):
+    """按已启用通知渠道构建 NotifierManager;无渠道返回 None。"""
+    from src.core.notifier import NotifierManager
+    from src.web.models import NotifyChannel
+
+    channels = db.query(NotifyChannel).filter(NotifyChannel.enabled.is_(True)).all()
+    if not channels:
+        return None
+    mgr = NotifierManager()
+    for ch in channels:
+        try:
+            mgr.add_channel(ch.type, ch.config or {})
+        except Exception:
+            pass
+    return mgr
+
+
+async def selfcheck_and_notify(*, db=None, ttl_minutes: int = 360) -> dict:
+    """定时自检 数据源 + 系统基础项,有断的就去重通知。
+
+    自动降级(数据源按 priority 主备已存在)→ 这里补"挂了提醒"。
+    刻意**不探测 AI**(避免周期性调用成本)、**不真发通知探测项**;仅在发现 fail 时发一条告警。
+    同一组失败在 ttl 内只通知一次(notify_dedupe)。
+    """
+    own = db is None
+    db = db or SessionLocal()
+    try:
+        items = list_selfcheck_items(db=db, include_system=True)
+        keys = [i["key"] for i in items if i["category"] in ("datasource", "system")]
+        if not keys:
+            return {"checked": 0, "failed": 0, "notified": False}
+        res = await run_selfcheck(db=db, keys=keys, include_system=True)
+        fails = [i for i in res["items"] if i["status"] == "fail"]
+        if not fails:
+            return {"checked": len(res["items"]), "failed": 0, "notified": False}
+
+        scope = "selfcheck:" + ",".join(sorted(f["key"] for f in fails))
+        if not check_and_mark_notify(agent_name="selfcheck", scope=scope, ttl_minutes=ttl_minutes, mark=True):
+            return {"checked": len(res["items"]), "failed": len(fails), "notified": False}
+
+        mgr = _notifier_from_db(db)
+        if mgr is None:
+            return {"checked": len(res["items"]), "failed": len(fails), "notified": False}
+
+        lines = []
+        for f in fails:
+            line = f"· {f['name']}:{f.get('error') or '异常'}"
+            if f.get("hint"):
+                line += f"\n  → {f['hint']}"
+            lines.append(line)
+        title = f"⚠️ PanWatch 自检:{len(fails)} 项异常"
+        content = "系统自检发现异常(数据源已按优先级自动降级,请尽快修复):\n\n" + "\n".join(lines)
+        await mgr.notify_with_result(title=title, content=content)
+        return {"checked": len(res["items"]), "failed": len(fails), "notified": True}
     finally:
         if own:
             db.close()

--- a/tests/test_selfcheck.py
+++ b/tests/test_selfcheck.py
@@ -59,6 +59,90 @@ def test_hint_notify_invalid():
     assert "配置" in h or "URI" in h or "格式" in h
 
 
+def test_hint_system_disk():
+    """磁盘类错误 → 提示空间/清理。"""
+    from src.core.selfcheck import classify_hint
+
+    h = classify_hint("system", "disk space low: only 50MB free")
+    assert "磁盘" in h or "空间" in h
+
+
+def test_hint_system_scheduler():
+    """调度器停止 → 提示重启。"""
+    from src.core.selfcheck import classify_hint
+
+    h = classify_hint("system", "scheduler stopped")
+    assert "调度" in h
+
+
+# --------------------------- 基础项探测(DB/磁盘/调度)---------------------------
+
+def test_probe_db_ok():
+    """DB 探测对真实库执行 SELECT 1,应通。"""
+    from src.core.selfcheck import probe_db
+
+    r = asyncio.run(probe_db())
+    assert r["category"] == "system" and r["key"] == "sys:db"
+    assert r["status"] in ("ok", "slow")
+
+
+def test_probe_disk_ok():
+    """磁盘探测返回用量,正常机器应通且带 note。"""
+    from src.core.selfcheck import probe_disk
+
+    r = asyncio.run(probe_disk())
+    assert r["key"] == "sys:disk"
+    assert r["status"] in ("ok", "slow", "fail")
+    assert r["note"]  # 显示可用/总量
+
+
+def test_probe_scheduler_empty_registry_ok():
+    """无注册调度器(如 CLI/未启动)→ ok 但带说明,不误报断。"""
+    from src.core import scheduler_registry
+    from src.core.selfcheck import probe_scheduler
+
+    scheduler_registry.clear()
+    r = asyncio.run(probe_scheduler())
+    assert r["key"] == "sys:scheduler" and r["status"] == "ok"
+    assert r["note"]
+
+
+def test_probe_scheduler_running():
+    """注册了运行中的调度器 → ok,note 含任务数。"""
+    from src.core import scheduler_registry
+    from src.core.selfcheck import probe_scheduler
+
+    class _FakeSched:
+        running = True
+
+        def get_jobs(self):
+            return [1, 2, 3]
+
+    scheduler_registry.clear()
+    scheduler_registry.register("agent", _FakeSched())
+    try:
+        r = asyncio.run(probe_scheduler())
+        assert r["status"] == "ok"
+        assert "3" in r["note"]
+    finally:
+        scheduler_registry.clear()
+
+
+def test_run_selfcheck_always_includes_system_items():
+    """空库也含 3 个系统基础项(数据库/磁盘/调度)。"""
+    from src.core.selfcheck import run_selfcheck
+
+    db = _mem_db()
+    try:
+        from src.core import scheduler_registry
+        scheduler_registry.clear()
+        res = asyncio.run(run_selfcheck(db=db))
+        keys = {i["key"] for i in res["items"]}
+        assert {"sys:db", "sys:disk", "sys:scheduler"} <= keys
+    finally:
+        db.close()
+
+
 # --------------------------- run_selfcheck(聚合)---------------------------
 
 def test_run_selfcheck_aggregates(monkeypatch):
@@ -92,7 +176,7 @@ def test_run_selfcheck_aggregates(monkeypatch):
         monkeypatch.setattr(selfcheck, "probe_ai_model", fake_ai)
         monkeypatch.setattr(selfcheck, "probe_notify_channel", fake_nc)
 
-        res = asyncio.run(selfcheck.run_selfcheck(db=db))
+        res = asyncio.run(selfcheck.run_selfcheck(db=db, include_system=False))
         assert res["summary"] == {"total": 3, "ok": 2, "slow": 0, "fail": 1}
         assert {i["category"] for i in res["items"]} == {"datasource", "ai", "notify"}
     finally:
@@ -105,7 +189,7 @@ def test_run_selfcheck_empty_db():
 
     db = _mem_db()
     try:
-        res = asyncio.run(run_selfcheck(db=db))
+        res = asyncio.run(run_selfcheck(db=db, include_system=False))
         assert res["summary"]["total"] == 0
         assert res["items"] == []
     finally:
@@ -132,7 +216,7 @@ def test_list_selfcheck_items_no_probe(monkeypatch):
         monkeypatch.setattr(selfcheck, "probe_datasource", boom)
         monkeypatch.setattr(selfcheck, "probe_notify_channel", boom)
 
-        items = selfcheck.list_selfcheck_items(db=db)
+        items = selfcheck.list_selfcheck_items(db=db, include_system=False)
         assert {i["key"] for i in items} == {"ds:1", "nc:1"}
         assert all({"category", "key", "name", "group"} <= set(i) for i in items)
         assert called["n"] == 0  # 没触发任何探测
@@ -212,3 +296,108 @@ def test_selfcheck_route_mounted():
     from src.web.app import app
 
     assert "/api/health/selfcheck" in set(app.openapi().get("paths", {}).keys())
+
+
+# --------------------------- CLI doctor ---------------------------
+
+def test_doctor_print_report(capsys):
+    """make doctor 的报告:分组打印 + 失败项带错误与中文建议。"""
+    from src.core.doctor import _print_report
+
+    res = {
+        "summary": {"total": 2, "ok": 1, "slow": 0, "fail": 1},
+        "items": [
+            {"category": "system", "key": "sys:db", "name": "数据库", "group": None,
+             "status": "ok", "latency_ms": 5, "error": None, "hint": "", "note": None},
+            {"category": "datasource", "key": "ds:1", "name": "东财", "group": None,
+             "status": "fail", "latency_ms": 0, "error": "timeout", "hint": "检查代理设置", "note": None},
+        ],
+    }
+    _print_report(res)
+    out = capsys.readouterr().out
+    assert "系统自检" in out
+    assert "【系统】" in out and "【数据源】" in out
+    assert "数据库" in out and "东财" in out
+    assert "检查代理设置" in out and "❌" in out
+
+
+# --------------------------- 降级提醒 selfcheck_and_notify ---------------------------
+
+def _ds_list(**_k):
+    return [{"category": "datasource", "key": "ds:1", "name": "东财", "group": None}]
+
+
+def test_selfcheck_and_notify_alerts_on_fail(monkeypatch):
+    """数据源断 → 发去重告警,内容含名称与修复建议。"""
+    from src.core import selfcheck
+
+    monkeypatch.setattr(selfcheck, "list_selfcheck_items", _ds_list)
+
+    async def fake_run(**_k):
+        return {"items": [{"category": "datasource", "key": "ds:1", "name": "东财", "group": None,
+                           "status": "fail", "latency_ms": 0, "error": "timeout",
+                           "hint": "检查代理", "note": None}],
+                "summary": {"total": 1, "ok": 0, "slow": 0, "fail": 1}, "notify_send": False}
+
+    monkeypatch.setattr(selfcheck, "run_selfcheck", fake_run)
+    monkeypatch.setattr(selfcheck, "check_and_mark_notify", lambda **k: True)
+    sent = {}
+
+    class FakeMgr:
+        async def notify_with_result(self, *, title, content, **k):
+            sent["title"] = title
+            sent["content"] = content
+            return {"success": True}
+
+    monkeypatch.setattr(selfcheck, "_notifier_from_db", lambda db: FakeMgr())
+    db = _mem_db()
+    try:
+        res = asyncio.run(selfcheck.selfcheck_and_notify(db=db))
+        assert res["notified"] is True and res["failed"] == 1
+        assert "东财" in sent["content"] and "检查代理" in sent["content"]
+    finally:
+        db.close()
+
+
+def test_selfcheck_and_notify_dedup(monkeypatch):
+    """同组失败在 TTL 内去重 → 不重复发。"""
+    from src.core import selfcheck
+
+    monkeypatch.setattr(selfcheck, "list_selfcheck_items", _ds_list)
+
+    async def fake_run(**_k):
+        return {"items": [{"category": "datasource", "key": "ds:1", "name": "东财", "group": None,
+                           "status": "fail", "latency_ms": 0, "error": "x", "hint": "", "note": None}],
+                "summary": {"total": 1, "ok": 0, "slow": 0, "fail": 1}, "notify_send": False}
+
+    monkeypatch.setattr(selfcheck, "run_selfcheck", fake_run)
+    monkeypatch.setattr(selfcheck, "check_and_mark_notify", lambda **k: False)
+    built = {"n": 0}
+    monkeypatch.setattr(selfcheck, "_notifier_from_db", lambda db: built.__setitem__("n", built["n"] + 1))
+    db = _mem_db()
+    try:
+        res = asyncio.run(selfcheck.selfcheck_and_notify(db=db))
+        assert res["notified"] is False
+        assert built["n"] == 0  # 去重后连通知都不构建
+    finally:
+        db.close()
+
+
+def test_selfcheck_and_notify_all_ok(monkeypatch):
+    """全通 → 不发。"""
+    from src.core import selfcheck
+
+    monkeypatch.setattr(selfcheck, "list_selfcheck_items", _ds_list)
+
+    async def fake_run(**_k):
+        return {"items": [{"category": "datasource", "key": "ds:1", "name": "东财", "group": None,
+                           "status": "ok", "latency_ms": 1, "error": None, "hint": "", "note": None}],
+                "summary": {"total": 1, "ok": 1, "slow": 0, "fail": 0}, "notify_send": False}
+
+    monkeypatch.setattr(selfcheck, "run_selfcheck", fake_run)
+    db = _mem_db()
+    try:
+        res = asyncio.run(selfcheck.selfcheck_and_notify(db=db))
+        assert res["notified"] is False and res["failed"] == 0
+    finally:
+        db.close()


### PR DESCRIPTION
## 系统自检二期

在一期(头像菜单弹窗自检)基础上补三块:

### 1. 基础项
`probe_db`(SELECT 1)/ `probe_disk`(data 盘用量)/ `probe_scheduler`(经 `scheduler_registry`,4 个调度器 start 时自注册)→ 并入自检「系统」类目(`include_system`,前端置顶)。

### 2. CLI `make doctor`
`src/core/doctor.py` + Makefile 目标:终端跑自检、打印结果+中文建议+退出码;CLI 无运行调度时该项优雅跳过。

### 3. 数据源降级提醒
`selfcheck_and_notify`:维护任务(`context_scheduler._evaluate_job`)定时自检 数据源+基础项,断则按失败集去重通知(notify_dedupe,TTL 6h)。自动降级(priority 主备)本就存在,这里补「挂了提醒」;**不探 AI**(免周期成本)、不真发探测项。

### 测试
后端 **407 passed**(+11 二期单测);前端 build 过;全模块导入正常。