### PR TITLE
feat(report): 分享卡体系(5 张卡 + 共享基建,带引流水印)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fn": "^0.0.2",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.300.0",
     "react": "^18.3.0",
     "react-day-picker": "^9.13.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       date-fn:
         specifier: ^0.0.2
         version: 0.0.2
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       lucide-react:
         specifier: ^0.300.0
         version: 0.300.0(react@18.3.1)
@@ -1196,6 +1199,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -2803,6 +2809,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 

--- a/frontend/src/components/BenchmarkShareCard.tsx
+++ b/frontend/src/components/BenchmarkShareCard.tsx
@@ -1,0 +1,175 @@
+import { type PortfolioBenchmark } from '@panwatch/api'
+import ShareCardDialog from './ShareCardDialog'
+
+interface BenchmarkShareCardProps {
+  open: boolean
+  onClose: () => void
+  bench: PortfolioBenchmark
+}
+
+// A股配色:红=涨/正、绿=跌/负、中性=琥珀
+const UP = '#e11d48'
+const DOWN = '#059669'
+const NEUTRAL = '#d97706'
+
+function signColor(v?: number | null): string {
+  if (v == null || !isFinite(v)) return NEUTRAL
+  if (v > 0) return UP
+  if (v < 0) return DOWN
+  return NEUTRAL
+}
+
+/** 百分比展示(带 +/- 号),数值已是百分比口径。 */
+function pct(v?: number | null, digits = 2): string {
+  if (v == null || !isFinite(v)) return '--'
+  return `${v > 0 ? '+' : ''}${v.toFixed(digits)}%`
+}
+
+function num(v?: number | null, digits = 2): string {
+  if (v == null || !isFinite(v)) return '--'
+  return v.toFixed(digits)
+}
+
+/**
+ * 净值 vs 基准双线 sparkline(纯 SVG,无外部依赖)。
+ * curve 里 portfolio/benchmark 为归一化净值(起点≈1 或 0,后端归一)。
+ * 这里对两条线统一做 min-max 归一,等比映射到画布,保证两线同坐标系可比。
+ */
+function Sparkline({
+  curve,
+  width = 568,
+  height = 96,
+}: {
+  curve: { date: string; portfolio: number; benchmark: number }[]
+  width?: number
+  height?: number
+}) {
+  const pad = 6
+  const xs = curve.length
+  if (xs < 2) return null
+  const allVals: number[] = []
+  for (const p of curve) {
+    if (isFinite(p.portfolio)) allVals.push(p.portfolio)
+    if (isFinite(p.benchmark)) allVals.push(p.benchmark)
+  }
+  if (allVals.length < 2) return null
+  let min = Math.min(...allVals)
+  let max = Math.max(...allVals)
+  if (max - min < 1e-9) {
+    max += 1
+    min -= 1
+  }
+  const innerW = width - pad * 2
+  const innerH = height - pad * 2
+  const xAt = (i: number) => pad + (innerW * i) / (xs - 1)
+  const yAt = (v: number) => pad + innerH - (innerH * (v - min)) / (max - min)
+  const path = (key: 'portfolio' | 'benchmark') =>
+    curve
+      .map((p, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i).toFixed(1)} ${yAt(p[key]).toFixed(1)}`)
+      .join(' ')
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} style={{ display: 'block' }}>
+      {/* 基准:灰色 */}
+      <path d={path('benchmark')} fill="none" stroke="#94a3b8" strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+      {/* 组合:品牌红(看多色,突出主角) */}
+      <path d={path('portfolio')} fill="none" stroke={UP} strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function StatBox({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#ffffff',
+        border: '1px solid #e2e8f0',
+        borderRadius: 12,
+        padding: '12px 14px',
+      }}
+    >
+      <div style={{ fontSize: 12, color: '#64748b', marginBottom: 6 }}>{label}</div>
+      <div style={{ fontSize: 20, fontWeight: 800, color: color ?? '#0f172a', fontVariantNumeric: 'tabular-nums' }}>
+        {value}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 模拟盘成绩单卡(vs 基准)。脱敏:全程只展示百分比 / 比率,绝不出现任何金额(¥)。
+ */
+export default function BenchmarkShareCard({ open, onClose, bench }: BenchmarkShareCardProps) {
+  const days = bench.days ?? 60
+  const benchLabel = bench.benchmark_label || '沪深300'
+  const excess = bench.excess_return
+  const heroColor = signColor(excess)
+  const curve = (bench.curve || []).filter((p) => isFinite(p.portfolio) && isFinite(p.benchmark))
+
+  return (
+    <ShareCardDialog open={open} onClose={onClose} filename={`AI模拟盘成绩单-近${days}天`}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontSize: 22, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>
+          AI 模拟盘成绩单
+        </div>
+        <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>近 {days} 天</div>
+      </div>
+
+      {/* Hero:超额收益 */}
+      <div
+        style={{
+          marginTop: 18,
+          borderRadius: 18,
+          padding: '22px 24px',
+          background: `linear-gradient(135deg, ${heroColor} 0%, ${heroColor}cc 100%)`,
+          color: '#ffffff',
+          boxShadow: `0 10px 30px -8px ${heroColor}66`,
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600, letterSpacing: 1, opacity: 0.92 }}>
+          超额收益(vs {benchLabel})
+        </div>
+        <div style={{ fontSize: 48, fontWeight: 900, lineHeight: 1.05, letterSpacing: 1, marginTop: 6 }}>
+          {pct(excess, 1)}
+        </div>
+      </div>
+
+      {/* 关键指标四宫格 */}
+      <div style={{ marginTop: 16, display: 'flex', gap: 12 }}>
+        <StatBox label="组合收益" value={pct(bench.portfolio_return, 1)} color={signColor(bench.portfolio_return)} />
+        <StatBox label={`${benchLabel}`} value={pct(bench.benchmark_return, 1)} color={signColor(bench.benchmark_return)} />
+      </div>
+      <div style={{ marginTop: 12, display: 'flex', gap: 12 }}>
+        <StatBox label="信息比率" value={num(bench.information_ratio, 2)} />
+        <StatBox label="相对回撤" value={pct(bench.relative_drawdown, 1)} color={signColor(bench.relative_drawdown)} />
+      </div>
+
+      {/* 净值 vs 基准 sparkline */}
+      {curve.length >= 2 && (
+        <div
+          style={{
+            marginTop: 16,
+            background: '#ffffff',
+            border: '1px solid #e2e8f0',
+            borderRadius: 12,
+            padding: '14px 14px 10px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 6 }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#64748b' }}>
+              <span style={{ width: 14, height: 3, borderRadius: 2, background: UP, display: 'inline-block' }} />
+              组合净值
+            </span>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#64748b' }}>
+              <span style={{ width: 14, height: 3, borderRadius: 2, background: '#94a3b8', display: 'inline-block' }} />
+              {benchLabel}
+            </span>
+          </div>
+          <Sparkline curve={curve} />
+        </div>
+      )}
+    </ShareCardDialog>
+  )
+}

--- a/frontend/src/components/DiagnosticsShareCard.tsx
+++ b/frontend/src/components/DiagnosticsShareCard.tsx
@@ -1,0 +1,202 @@
+import { type PortfolioDiagnostics } from '@panwatch/api'
+import ShareCardDialog from './ShareCardDialog'
+
+interface DiagnosticsShareCardProps {
+  open: boolean
+  onClose: () => void
+  diag: PortfolioDiagnostics
+  /** 可选:近 N 日相对大盘超额(%),有则展示在副指标里。 */
+  excessReturn?: number | null
+  benchmarkLabel?: string
+}
+
+const UP = '#e11d48'
+const DOWN = '#059669'
+const NEUTRAL = '#d97706'
+const SLATE = '#0f172a'
+
+function signColor(v?: number | null): string {
+  if (v == null || !isFinite(v)) return NEUTRAL
+  if (v > 0) return UP
+  if (v < 0) return DOWN
+  return NEUTRAL
+}
+
+function pct(v?: number | null, digits = 1): string {
+  if (v == null || !isFinite(v)) return '--'
+  return `${v > 0 ? '+' : ''}${v.toFixed(digits)}%`
+}
+
+const MARKET_LABEL: Record<string, string> = { CN: 'A股', HK: '港股', US: '美股' }
+const marketLabel = (m: string) => MARKET_LABEL[m] || m
+
+/**
+ * 集中度(HHI)定性:0~1,越高越集中。0.4+ 偏高,0.25~0.4 适中,<0.25 分散。
+ */
+function hhiBand(hhi: number): { label: string; color: string } {
+  if (hhi >= 0.4) return { label: '偏集中', color: NEUTRAL }
+  if (hhi >= 0.25) return { label: '适中', color: SLATE }
+  return { label: '较分散', color: DOWN }
+}
+
+function StatBox({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#ffffff',
+        border: '1px solid #e2e8f0',
+        borderRadius: 12,
+        padding: '12px 14px',
+      }}
+    >
+      <div style={{ fontSize: 12, color: '#64748b', marginBottom: 6 }}>{label}</div>
+      <div style={{ fontSize: 22, fontWeight: 800, color: color ?? SLATE, fontVariantNumeric: 'tabular-nums' }}>
+        {value}
+      </div>
+      {sub && <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 2 }}>{sub}</div>}
+    </div>
+  )
+}
+
+/**
+ * 组合体检卡。脱敏:只展示比例 / 数量 / 风险提示,绝不出现任何金额(¥)。
+ * total_market_value 仅用于把 by_market 的市值换算成「占比 %」,数值本身不展示。
+ */
+export default function DiagnosticsShareCard({
+  open,
+  onClose,
+  diag,
+  excessReturn,
+  benchmarkLabel,
+}: DiagnosticsShareCardProps) {
+  const band = hhiBand(diag.hhi)
+  const totalMv = diag.total_market_value || 0
+  const markets = Object.entries(diag.by_market || {})
+    .map(([m, v]) => ({ m, w: totalMv > 0 ? (v / totalMv) * 100 : 0 }))
+    .sort((a, b) => b.w - a.w)
+  const alerts = (diag.alerts || []).slice(0, 3)
+  const hasExcess = excessReturn != null && isFinite(excessReturn)
+
+  return (
+    <ShareCardDialog open={open} onClose={onClose} filename="组合体检卡">
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontSize: 22, fontWeight: 800, lineHeight: 1.2, color: SLATE }}>组合体检</div>
+        <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>持仓结构 · 风险</div>
+      </div>
+
+      {/* Hero:集中度(HHI) */}
+      <div
+        style={{
+          marginTop: 18,
+          borderRadius: 18,
+          padding: '22px 24px',
+          background: `linear-gradient(135deg, ${band.color} 0%, ${band.color}cc 100%)`,
+          color: '#ffffff',
+          boxShadow: `0 10px 30px -8px ${band.color}66`,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, letterSpacing: 1, opacity: 0.92, flexShrink: 0 }}>
+            集中度(HHI)
+          </div>
+          <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
+            <span style={{ fontSize: 42, fontWeight: 900, lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>
+              {diag.hhi.toFixed(2)}
+            </span>
+            <span style={{ fontSize: 18, fontWeight: 700, marginLeft: 10 }}>{band.label}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 关键指标 */}
+      <div style={{ marginTop: 16, display: 'flex', gap: 12 }}>
+        <StatBox label="持仓数" value={`${diag.position_count}`} sub="只" />
+        <StatBox
+          label="最大单仓占比"
+          value={`${(diag.max_weight * 100).toFixed(0)}%`}
+          color={diag.max_weight >= 0.4 ? NEUTRAL : SLATE}
+        />
+        {hasExcess && (
+          <StatBox
+            label={`近期相对${benchmarkLabel || '大盘'}`}
+            value={pct(excessReturn)}
+            color={signColor(excessReturn)}
+          />
+        )}
+      </div>
+
+      {/* 市场分布 */}
+      {markets.length > 0 && (
+        <div style={{ marginTop: 16 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#334155', marginBottom: 8 }}>市场分布</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {markets.map(({ m, w }) => (
+              <div key={m}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, marginBottom: 4 }}>
+                  <span style={{ color: '#475569' }}>{marketLabel(m)}</span>
+                  <span style={{ color: SLATE, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                    {w.toFixed(0)}%
+                  </span>
+                </div>
+                <div style={{ height: 8, borderRadius: 999, background: '#e2e8f0', overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${Math.min(100, w)}%`,
+                      borderRadius: 999,
+                      background: '#6366f1',
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 风险提示 */}
+      <div style={{ marginTop: 16 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: '#334155', marginBottom: 8 }}>风险提示</div>
+        {alerts.length > 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {alerts.map((a, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 8,
+                  background: '#fffbeb',
+                  border: '1px solid #fde68a',
+                  borderRadius: 10,
+                  padding: '10px 12px',
+                  fontSize: 13,
+                  lineHeight: 1.5,
+                  color: '#92400e',
+                }}
+              >
+                <span style={{ flexShrink: 0, fontWeight: 900 }}>!</span>
+                <span>{a}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div
+            style={{
+              background: '#ecfdf5',
+              border: '1px solid #a7f3d0',
+              borderRadius: 10,
+              padding: '10px 12px',
+              fontSize: 13,
+              color: '#065f46',
+            }}
+          >
+            ✓ 集中度 / 分布未见明显风险
+          </div>
+        )}
+      </div>
+    </ShareCardDialog>
+  )
+}

--- a/frontend/src/components/DigestShareCard.tsx
+++ b/frontend/src/components/DigestShareCard.tsx
@@ -1,0 +1,157 @@
+import ShareCardDialog from './ShareCardDialog'
+
+/** digest 单条:与 Dashboard 的 feed(CurateCandidate & { why }）同构。 */
+export interface DigestItem {
+  type: string // alert | holding | watch | risk | opportunity
+  name?: string
+  symbol?: string
+  why: string
+  change_pct?: number | null
+}
+
+interface DigestShareCardProps {
+  open: boolean
+  onClose: () => void
+  date: string
+  items: DigestItem[]
+}
+
+const UP = '#e11d48'
+const DOWN = '#059669'
+
+function moveColor(v?: number | null): string {
+  if (v == null || !isFinite(v)) return '#94a3b8'
+  if (v > 0) return UP
+  if (v < 0) return DOWN
+  return '#94a3b8'
+}
+function pct(v?: number | null): string {
+  if (v == null || !isFinite(v)) return ''
+  return `${v > 0 ? '+' : ''}${v.toFixed(2)}%`
+}
+
+/** 各类型的徽标:文字 + 配色(emoji 作图标,纯文本可被 PNG 正确渲染,无外部图片)。 */
+const TYPE_BADGE: Record<string, { label: string; icon: string; color: string; bg: string }> = {
+  alert: { label: '提醒命中', icon: '🔔', color: '#e11d48', bg: '#fff1f2' },
+  holding: { label: '持仓', icon: '📊', color: '#059669', bg: '#ecfdf5' },
+  watch: { label: '自选', icon: '👀', color: '#475569', bg: '#f1f5f9' },
+  risk: { label: '风险', icon: '⚠️', color: '#d97706', bg: '#fffbeb' },
+  opportunity: { label: '机会', icon: '✨', color: '#6366f1', bg: '#eef2ff' },
+}
+const FALLBACK_BADGE = { label: '要点', icon: '•', color: '#475569', bg: '#f1f5f9' }
+
+/**
+ * 每日 digest 卡:今日盯盘要点(持仓异动 / 机会 / 风险 / 提醒)。保持可扫读。
+ */
+export default function DigestShareCard({ open, onClose, date, items }: DigestShareCardProps) {
+  const list = (items || []).slice(0, 8)
+
+  return (
+    <ShareCardDialog open={open} onClose={onClose} filename={`今日盯盘-${date}`}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontSize: 22, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>今日盯盘</div>
+        <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>{date}</div>
+      </div>
+      <div style={{ marginTop: 6, fontSize: 13, color: '#64748b' }}>
+        持仓异动 / 机会 / 风险提醒 · AI 为你梳理的今日要点
+      </div>
+
+      {/* 要点列表 */}
+      <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {list.length === 0 ? (
+          <div
+            style={{
+              background: '#ecfdf5',
+              border: '1px solid #a7f3d0',
+              borderRadius: 10,
+              padding: '14px 16px',
+              fontSize: 14,
+              color: '#065f46',
+            }}
+          >
+            ✓ 今日暂无明显异动或触发信号
+          </div>
+        ) : (
+          list.map((it, i) => {
+            const badge = TYPE_BADGE[it.type] || FALLBACK_BADGE
+            const change = pct(it.change_pct)
+            return (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 12,
+                  background: '#ffffff',
+                  border: '1px solid #e2e8f0',
+                  borderRadius: 12,
+                  padding: '11px 14px',
+                }}
+              >
+                <span
+                  style={{
+                    flexShrink: 0,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    background: badge.bg,
+                    color: badge.color,
+                    borderRadius: 8,
+                    padding: '4px 9px',
+                    fontSize: 12,
+                    fontWeight: 700,
+                  }}
+                >
+                  <span style={{ fontSize: 13 }}>{badge.icon}</span>
+                  {badge.label}
+                </span>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  {it.name && (
+                    <div
+                      style={{
+                        fontSize: 14,
+                        fontWeight: 700,
+                        color: '#0f172a',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {it.name}
+                    </div>
+                  )}
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      color: '#64748b',
+                      lineHeight: 1.5,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {it.why}
+                  </div>
+                </div>
+                {change && (
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      fontSize: 14,
+                      fontWeight: 800,
+                      color: moveColor(it.change_pct),
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {change}
+                  </span>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </ShareCardDialog>
+  )
+}

--- a/frontend/src/components/ShareCardDialog.tsx
+++ b/frontend/src/components/ShareCardDialog.tsx
@@ -1,0 +1,148 @@
+import { useRef, useState, type ReactNode } from 'react'
+import { toPng } from 'html-to-image'
+import { ImageDown, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@panwatch/base-ui/components/ui/dialog'
+import { Button } from '@panwatch/base-ui/components/ui/button'
+
+interface ShareCardDialogProps {
+  open: boolean
+  onClose: () => void
+  /** 导出 PNG 文件名(不含扩展名)。 */
+  filename: string
+  /** 卡片固定宽度,默认 640。 */
+  width?: number
+  /** 卡片正脸内容,由各业务卡传入。颜色须显式内联,勿依赖主题 CSS 变量。 */
+  children: ReactNode
+}
+
+/**
+ * 分享卡通用外壳:统一的 Dialog + 固定宽度卡片容器 + 品牌页脚 + 「下载图片」按钮。
+ *
+ * 设计要点:
+ * - 卡片容器固定宽度(默认 640px),自带白→#f8fafc 渐变背景、圆角、内边距、系统字体、显式深色文字,
+ *   保证导出 PNG 在任何主题(亮/暗)下都一致。各业务卡只需提供「正脸」children。
+ * - 页脚(免责 + 盯盘侠 PanWatch · github 引流行)由外壳统一渲染,作为全体分享卡的一致性锚点。
+ * - 「下载图片」用 html-to-image 的 toPng(pixelRatio:2, cacheBust:true)导出为 ${filename}.png。
+ */
+export default function ShareCardDialog({
+  open,
+  onClose,
+  filename,
+  width = 640,
+  children,
+}: ShareCardDialogProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [busy, setBusy] = useState(false)
+
+  const handleDownload = async () => {
+    if (busy || !cardRef.current) return
+    setBusy(true)
+    try {
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: true })
+      const link = document.createElement('a')
+      link.download = `${filename}.png`
+      link.href = dataUrl
+      link.click()
+    } catch (e) {
+      alert(e instanceof Error ? `图片生成失败:${e.message}` : '图片生成失败,请重试')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>分享图片</DialogTitle>
+          <DialogDescription>导出一张干净的卡片,可分享到雪球 / 微信群。</DialogDescription>
+        </DialogHeader>
+
+        {/* 预览区:外层用主题背景,内层卡片自带显式配色 */}
+        <div className="flex justify-center overflow-x-auto rounded-xl bg-accent/30 p-4 scrollbar">
+          {/* 导出卡片:固定宽度,所有颜色显式内联,不依赖主题 CSS 变量 */}
+          <div
+            ref={cardRef}
+            style={{
+              width,
+              boxSizing: 'border-box',
+              background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
+              borderRadius: 24,
+              padding: '32px 36px',
+              border: '1px solid #e2e8f0',
+              fontFamily:
+                '-apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", "Segoe UI", sans-serif',
+              color: '#0f172a',
+            }}
+          >
+            {/* 业务卡正脸 */}
+            {children}
+
+            {/* 分割线 */}
+            <div style={{ height: 1, background: '#e2e8f0', margin: '24px 0 16px' }} />
+
+            {/* 页脚:免责 + 品牌引流行(全体分享卡一致) */}
+            <div style={{ fontSize: 12, color: '#94a3b8', lineHeight: 1.6 }}>
+              仅供参考,不构成投资建议
+            </div>
+            <div
+              style={{
+                marginTop: 8,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                fontSize: 13.5,
+                fontWeight: 700,
+                color: '#0f172a',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 22,
+                  height: 22,
+                  borderRadius: 6,
+                  background: '#0f172a',
+                  color: '#ffffff',
+                  fontSize: 13,
+                  fontWeight: 900,
+                  flexShrink: 0,
+                }}
+              >
+                盯
+              </span>
+              <span>盯盘侠 PanWatch</span>
+              <span style={{ color: '#cbd5e1', fontWeight: 400 }}>·</span>
+              <span style={{ color: '#64748b', fontWeight: 500, fontSize: 12.5 }}>
+                github.com/TNT-Likely/PanWatch
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* 操作区 */}
+        <div className="mt-4 flex items-center justify-end gap-3">
+          <Button variant="outline" size="sm" className="h-9" onClick={onClose} disabled={busy}>
+            关闭
+          </Button>
+          <Button size="sm" className="h-9" onClick={() => void handleDownload()} disabled={busy}>
+            {busy ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <ImageDown className="w-3.5 h-3.5" />
+            )}
+            {busy ? '生成中…' : '下载图片'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/ShareCardModal.tsx
+++ b/frontend/src/components/ShareCardModal.tsx
@@ -1,16 +1,6 @@
-import { useRef, useState } from 'react'
-import { toPng } from 'html-to-image'
-import { ImageDown, Loader2 } from 'lucide-react'
 import { type DeepAnalysisResult } from '@panwatch/api'
 import { normalizeSuggestionAction } from '@panwatch/biz-ui/components/suggestion-action'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@panwatch/base-ui/components/ui/dialog'
-import { Button } from '@panwatch/base-ui/components/ui/button'
+import ShareCardDialog from './ShareCardDialog'
 
 interface ShareCardModalProps {
   open: boolean
@@ -79,9 +69,6 @@ function cleanConclusion(text: string): string {
 }
 
 export default function ShareCardModal({ open, onClose, result, symbol, date }: ShareCardModalProps) {
-  const cardRef = useRef<HTMLDivElement>(null)
-  const [busy, setBusy] = useState(false)
-
   const sug = result.raw_data?.suggestion
   // 评级来源:优先后端五档原值 rating_raw(类型未声明,运行时可能有),否则用 action,再叠加中文 action_label 兜底
   const ratingRaw = mapRatingRaw((sug as { rating_raw?: string } | undefined)?.rating_raw)
@@ -94,218 +81,120 @@ export default function ShareCardModal({ open, onClose, result, symbol, date }: 
   const conclusion = cleanConclusion(sug?.signal || sug?.reason || '')
   const confPct = Math.max(0, Math.min(100, (confidence ?? 0) * 10))
 
-  const handleDownload = async () => {
-    if (busy || !cardRef.current) return
-    setBusy(true)
-    try {
-      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: true })
-      const link = document.createElement('a')
-      link.download = `${stockName}-${date}-分析卡片.png`
-      link.href = dataUrl
-      link.click()
-    } catch (e) {
-      alert(e instanceof Error ? `图片生成失败:${e.message}` : '图片生成失败,请重试')
-    } finally {
-      setBusy(false)
-    }
-  }
-
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>分享图片</DialogTitle>
-          <DialogDescription>
-            导出一张干净的结论卡片,可分享到雪球 / 微信群。
-          </DialogDescription>
-        </DialogHeader>
+    <ShareCardDialog open={open} onClose={onClose} filename={`${stockName}-${date}-分析卡片`}>
+      {/* Header:股票名+代码 / 日期 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 12,
+        }}
+      >
+        <div style={{ fontSize: 24, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>
+          {stockName}
+        </div>
+        <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>{date}</div>
+      </div>
 
-        {/* 预览区:外层用主题背景,内层卡片自带显式配色 */}
-        <div className="flex justify-center overflow-x-auto rounded-xl bg-accent/30 p-4 scrollbar">
-          {/* 导出卡片:固定 640px 宽,所有颜色显式内联,不依赖主题 CSS 变量 */}
+      {/* Hero:大评级 + 置信度条 + 成本 */}
+      <div
+        style={{
+          marginTop: 20,
+          borderRadius: 18,
+          padding: '22px 24px',
+          background: `linear-gradient(135deg, ${visual.gradFrom} 0%, ${visual.gradTo} 100%)`,
+          color: '#ffffff',
+          boxShadow: `0 10px 30px -8px ${visual.color}66`,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
           <div
-            ref={cardRef}
             style={{
-              width: 640,
-              boxSizing: 'border-box',
-              background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
-              borderRadius: 24,
-              padding: '32px 36px',
-              border: '1px solid #e2e8f0',
-              fontFamily:
-                '-apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", "Segoe UI", sans-serif',
-              color: '#0f172a',
+              fontSize: 13,
+              fontWeight: 600,
+              letterSpacing: 1,
+              opacity: 0.92,
+              flexShrink: 0,
             }}
           >
-            {/* Header:股票名+代码 / 日期 */}
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'baseline',
-                justifyContent: 'space-between',
-                gap: 12,
-              }}
-            >
-              <div style={{ fontSize: 24, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>
-                {stockName}
-              </div>
-              <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>
-                {date}
-              </div>
-            </div>
-
-            {/* Hero:大评级 + 置信度条 + 成本 */}
-            <div
-              style={{
-                marginTop: 20,
-                borderRadius: 18,
-                padding: '22px 24px',
-                background: `linear-gradient(135deg, ${visual.gradFrom} 0%, ${visual.gradTo} 100%)`,
-                color: '#ffffff',
-                boxShadow: `0 10px 30px -8px ${visual.color}66`,
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                <div
-                  style={{
-                    fontSize: 13,
-                    fontWeight: 600,
-                    letterSpacing: 1,
-                    opacity: 0.92,
-                    flexShrink: 0,
-                  }}
-                >
-                  AI 投研结论
-                </div>
-                <div
-                  style={{
-                    fontSize: 42,
-                    fontWeight: 900,
-                    lineHeight: 1,
-                    letterSpacing: 2,
-                    marginLeft: 'auto',
-                  }}
-                >
-                  {visual.label}
-                </div>
-              </div>
-
-              {/* 置信度条 */}
-              <div style={{ marginTop: 18 }}>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: 12.5,
-                    opacity: 0.92,
-                    marginBottom: 6,
-                  }}
-                >
-                  <span>置信度</span>
-                  <span style={{ fontWeight: 700 }}>
-                    {confidence != null ? confidence.toFixed(1) : '-'} / 10
-                  </span>
-                </div>
-                <div
-                  style={{
-                    height: 8,
-                    borderRadius: 999,
-                    background: 'rgba(255,255,255,0.3)',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      height: '100%',
-                      width: `${confPct}%`,
-                      borderRadius: 999,
-                      background: '#ffffff',
-                    }}
-                  />
-                </div>
-                <div style={{ marginTop: 10, fontSize: 12, opacity: 0.85 }}>
-                  分析成本 ${costUsd != null ? costUsd.toFixed(4) : '-'}
-                </div>
-              </div>
-            </div>
-
-            {/* 结论段落:最多约 5 行 */}
-            {conclusion && (
-              <div
-                style={{
-                  marginTop: 22,
-                  fontSize: 15.5,
-                  lineHeight: 1.7,
-                  color: '#334155',
-                  display: '-webkit-box',
-                  WebkitLineClamp: 5,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                }}
-              >
-                {conclusion}
-              </div>
-            )}
-
-            {/* 分割线 */}
-            <div style={{ height: 1, background: '#e2e8f0', margin: '24px 0 16px' }} />
-
-            {/* Footer:免责 + 品牌引流行 */}
-            <div style={{ fontSize: 12, color: '#94a3b8', lineHeight: 1.6 }}>
-              AI 投研团队(9-Agent)深度分析 · 仅供参考,不构成投资建议
-            </div>
-            <div
-              style={{
-                marginTop: 8,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                fontSize: 13.5,
-                fontWeight: 700,
-                color: '#0f172a',
-              }}
-            >
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: 22,
-                  height: 22,
-                  borderRadius: 6,
-                  background: visual.color,
-                  color: '#ffffff',
-                  fontSize: 13,
-                  fontWeight: 900,
-                  flexShrink: 0,
-                }}
-              >
-                盯
-              </span>
-              <span>盯盘侠 PanWatch</span>
-              <span style={{ color: '#cbd5e1', fontWeight: 400 }}>·</span>
-              <span style={{ color: '#64748b', fontWeight: 500, fontSize: 12.5 }}>
-                github.com/TNT-Likely/PanWatch
-              </span>
-            </div>
+            AI 投研结论
+          </div>
+          <div
+            style={{
+              fontSize: 42,
+              fontWeight: 900,
+              lineHeight: 1,
+              letterSpacing: 2,
+              marginLeft: 'auto',
+            }}
+          >
+            {visual.label}
           </div>
         </div>
 
-        {/* 操作区 */}
-        <div className="mt-4 flex items-center justify-end gap-3">
-          <Button variant="outline" size="sm" className="h-9" onClick={onClose} disabled={busy}>
-            关闭
-          </Button>
-          <Button size="sm" className="h-9" onClick={() => void handleDownload()} disabled={busy}>
-            {busy ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <ImageDown className="w-3.5 h-3.5" />
-            )}
-            {busy ? '生成中…' : '下载图片'}
-          </Button>
+        {/* 置信度条 */}
+        <div style={{ marginTop: 18 }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontSize: 12.5,
+              opacity: 0.92,
+              marginBottom: 6,
+            }}
+          >
+            <span>置信度</span>
+            <span style={{ fontWeight: 700 }}>
+              {confidence != null ? confidence.toFixed(1) : '-'} / 10
+            </span>
+          </div>
+          <div
+            style={{
+              height: 8,
+              borderRadius: 999,
+              background: 'rgba(255,255,255,0.3)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${confPct}%`,
+                borderRadius: 999,
+                background: '#ffffff',
+              }}
+            />
+          </div>
+          <div style={{ marginTop: 10, fontSize: 12, opacity: 0.85 }}>
+            分析成本 ${costUsd != null ? costUsd.toFixed(4) : '-'}
+          </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      {/* 结论段落:最多约 5 行 */}
+      {conclusion && (
+        <div
+          style={{
+            marginTop: 22,
+            fontSize: 15.5,
+            lineHeight: 1.7,
+            color: '#334155',
+            display: '-webkit-box',
+            WebkitLineClamp: 5,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {conclusion}
+        </div>
+      )}
+
+      {/* TA 卡专属副标(9-Agent),置于外壳分割线/页脚之上 */}
+      <div style={{ marginTop: 22, fontSize: 12, color: '#94a3b8', lineHeight: 1.6 }}>
+        AI 投研团队(9-Agent)深度分析
+      </div>
+    </ShareCardDialog>
   )
 }

--- a/frontend/src/components/ShareCardModal.tsx
+++ b/frontend/src/components/ShareCardModal.tsx
@@ -1,0 +1,311 @@
+import { useRef, useState } from 'react'
+import { toPng } from 'html-to-image'
+import { ImageDown, Loader2 } from 'lucide-react'
+import { type DeepAnalysisResult } from '@panwatch/api'
+import { normalizeSuggestionAction } from '@panwatch/biz-ui/components/suggestion-action'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@panwatch/base-ui/components/ui/dialog'
+import { Button } from '@panwatch/base-ui/components/ui/button'
+
+interface ShareCardModalProps {
+  open: boolean
+  onClose: () => void
+  result: DeepAnalysisResult
+  symbol: string
+  date: string
+}
+
+/**
+ * 五档评级 → 展示标签 + A股配色(红涨绿跌)。
+ * 复用 technical-badge / suggestion-action 的归一化:买入/增持=红(看多)、卖出/减持=绿(看空)、持有=琥珀(中性)。
+ * 这里用自包含的显式十六进制色,保证导出 PNG 在任何主题(亮/暗)下都正确。
+ */
+const RATING_VISUAL: Record<
+  string,
+  { label: string; color: string; soft: string; gradFrom: string; gradTo: string }
+> = {
+  // 看多(红)
+  buy: { label: '买入', color: '#e11d48', soft: '#fff1f2', gradFrom: '#fb7185', gradTo: '#e11d48' },
+  add: { label: '增持', color: '#e11d48', soft: '#fff1f2', gradFrom: '#fda4af', gradTo: '#e11d48' },
+  // 中性(琥珀)
+  hold: { label: '持有', color: '#d97706', soft: '#fffbeb', gradFrom: '#fbbf24', gradTo: '#d97706' },
+  // 看空(绿)
+  reduce: { label: '减持', color: '#059669', soft: '#ecfdf5', gradFrom: '#34d399', gradTo: '#059669' },
+  sell: { label: '卖出', color: '#059669', soft: '#ecfdf5', gradFrom: '#6ee7b7', gradTo: '#059669' },
+}
+const RATING_FALLBACK = {
+  label: '观望',
+  color: '#475569',
+  soft: '#f8fafc',
+  gradFrom: '#94a3b8',
+  gradTo: '#475569',
+}
+
+/** 把后端可能存在的五档原值(overweight/underweight)映射到归一化器认得的词。 */
+function mapRatingRaw(raw?: string): string | undefined {
+  if (!raw) return undefined
+  const r = raw.toLowerCase().trim()
+  if (r === 'overweight') return 'add'
+  if (r === 'underweight') return 'reduce'
+  return r
+}
+
+/**
+ * 从标题解析股票名+代码:去掉开头的【深度】等方括号标记,去掉结尾的「:评级」。
+ * 例:「【深度】广汽集团(601238):持有」→「广汽集团(601238)」
+ */
+function parseStockName(title: string, symbol: string): string {
+  let s = (title || '').trim()
+  s = s.replace(/^【[^】]*】\s*/, '') // 去掉开头第一个【...】标记
+  s = s.replace(/[:：]\s*[^:：]*$/, '') // 去掉结尾「:xxx」(评级)
+  s = s.trim()
+  return s || symbol
+}
+
+/**
+ * 清洗结论为单段:去 markdown 加粗 **,再去开头的「Action: x Reasoning:」前缀。
+ * 多余空白压成单空格,便于 line-clamp 展示。
+ */
+function cleanConclusion(text: string): string {
+  let s = (text || '').replace(/\*\*/g, '')
+  s = s.replace(/^Action\s*[:：]\s*\S+\s*Reasoning\s*[:：]\s*/i, '')
+  s = s.replace(/\s+/g, ' ').trim()
+  return s
+}
+
+export default function ShareCardModal({ open, onClose, result, symbol, date }: ShareCardModalProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [busy, setBusy] = useState(false)
+
+  const sug = result.raw_data?.suggestion
+  // 评级来源:优先后端五档原值 rating_raw(类型未声明,运行时可能有),否则用 action,再叠加中文 action_label 兜底
+  const ratingRaw = mapRatingRaw((sug as { rating_raw?: string } | undefined)?.rating_raw)
+  const normalized = normalizeSuggestionAction(ratingRaw || sug?.action, sug?.action_label)
+  const visual = (normalized && RATING_VISUAL[normalized]) || RATING_FALLBACK
+
+  const stockName = parseStockName(result.title || '', symbol)
+  const confidence = sug?.confidence
+  const costUsd = result.raw_data?.cost_usd
+  const conclusion = cleanConclusion(sug?.signal || sug?.reason || '')
+  const confPct = Math.max(0, Math.min(100, (confidence ?? 0) * 10))
+
+  const handleDownload = async () => {
+    if (busy || !cardRef.current) return
+    setBusy(true)
+    try {
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: true })
+      const link = document.createElement('a')
+      link.download = `${stockName}-${date}-分析卡片.png`
+      link.href = dataUrl
+      link.click()
+    } catch (e) {
+      alert(e instanceof Error ? `图片生成失败:${e.message}` : '图片生成失败,请重试')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>分享图片</DialogTitle>
+          <DialogDescription>
+            导出一张干净的结论卡片,可分享到雪球 / 微信群。
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* 预览区:外层用主题背景,内层卡片自带显式配色 */}
+        <div className="flex justify-center overflow-x-auto rounded-xl bg-accent/30 p-4 scrollbar">
+          {/* 导出卡片:固定 640px 宽,所有颜色显式内联,不依赖主题 CSS 变量 */}
+          <div
+            ref={cardRef}
+            style={{
+              width: 640,
+              boxSizing: 'border-box',
+              background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
+              borderRadius: 24,
+              padding: '32px 36px',
+              border: '1px solid #e2e8f0',
+              fontFamily:
+                '-apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", "Segoe UI", sans-serif',
+              color: '#0f172a',
+            }}
+          >
+            {/* Header:股票名+代码 / 日期 */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                justifyContent: 'space-between',
+                gap: 12,
+              }}
+            >
+              <div style={{ fontSize: 24, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>
+                {stockName}
+              </div>
+              <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>
+                {date}
+              </div>
+            </div>
+
+            {/* Hero:大评级 + 置信度条 + 成本 */}
+            <div
+              style={{
+                marginTop: 20,
+                borderRadius: 18,
+                padding: '22px 24px',
+                background: `linear-gradient(135deg, ${visual.gradFrom} 0%, ${visual.gradTo} 100%)`,
+                color: '#ffffff',
+                boxShadow: `0 10px 30px -8px ${visual.color}66`,
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    letterSpacing: 1,
+                    opacity: 0.92,
+                    flexShrink: 0,
+                  }}
+                >
+                  AI 投研结论
+                </div>
+                <div
+                  style={{
+                    fontSize: 42,
+                    fontWeight: 900,
+                    lineHeight: 1,
+                    letterSpacing: 2,
+                    marginLeft: 'auto',
+                  }}
+                >
+                  {visual.label}
+                </div>
+              </div>
+
+              {/* 置信度条 */}
+              <div style={{ marginTop: 18 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: 12.5,
+                    opacity: 0.92,
+                    marginBottom: 6,
+                  }}
+                >
+                  <span>置信度</span>
+                  <span style={{ fontWeight: 700 }}>
+                    {confidence != null ? confidence.toFixed(1) : '-'} / 10
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 8,
+                    borderRadius: 999,
+                    background: 'rgba(255,255,255,0.3)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${confPct}%`,
+                      borderRadius: 999,
+                      background: '#ffffff',
+                    }}
+                  />
+                </div>
+                <div style={{ marginTop: 10, fontSize: 12, opacity: 0.85 }}>
+                  分析成本 ${costUsd != null ? costUsd.toFixed(4) : '-'}
+                </div>
+              </div>
+            </div>
+
+            {/* 结论段落:最多约 5 行 */}
+            {conclusion && (
+              <div
+                style={{
+                  marginTop: 22,
+                  fontSize: 15.5,
+                  lineHeight: 1.7,
+                  color: '#334155',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 5,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {conclusion}
+              </div>
+            )}
+
+            {/* 分割线 */}
+            <div style={{ height: 1, background: '#e2e8f0', margin: '24px 0 16px' }} />
+
+            {/* Footer:免责 + 品牌引流行 */}
+            <div style={{ fontSize: 12, color: '#94a3b8', lineHeight: 1.6 }}>
+              AI 投研团队(9-Agent)深度分析 · 仅供参考,不构成投资建议
+            </div>
+            <div
+              style={{
+                marginTop: 8,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                fontSize: 13.5,
+                fontWeight: 700,
+                color: '#0f172a',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 22,
+                  height: 22,
+                  borderRadius: 6,
+                  background: visual.color,
+                  color: '#ffffff',
+                  fontSize: 13,
+                  fontWeight: 900,
+                  flexShrink: 0,
+                }}
+              >
+                盯
+              </span>
+              <span>盯盘侠 PanWatch</span>
+              <span style={{ color: '#cbd5e1', fontWeight: 400 }}>·</span>
+              <span style={{ color: '#64748b', fontWeight: 500, fontSize: 12.5 }}>
+                github.com/TNT-Likely/PanWatch
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* 操作区 */}
+        <div className="mt-4 flex items-center justify-end gap-3">
+          <Button variant="outline" size="sm" className="h-9" onClick={onClose} disabled={busy}>
+            关闭
+          </Button>
+          <Button size="sm" className="h-9" onClick={() => void handleDownload()} disabled={busy}>
+            {busy ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <ImageDown className="w-3.5 h-3.5" />
+            )}
+            {busy ? '生成中…' : '下载图片'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/SignalScoreShareCard.tsx
+++ b/frontend/src/components/SignalScoreShareCard.tsx
@@ -1,0 +1,198 @@
+import { type StrategySignalItem } from '@panwatch/api'
+import ShareCardDialog from './ShareCardDialog'
+
+interface SignalScoreShareCardProps {
+  open: boolean
+  onClose: () => void
+  item: StrategySignalItem
+}
+
+// A股配色:看多=红、看空/中性等
+const UP = '#e11d48'
+const NEUTRAL = '#d97706'
+const SLATE = '#475569'
+
+const MARKET_LABEL: Record<string, string> = { CN: 'A股', HK: '港股', US: '美股' }
+const marketLabel = (m?: string) => (m ? MARKET_LABEL[m] || m : '')
+
+/**
+ * action → 展示标签 + 配色(与机会页一致:buy/add 看多偏红,hold 中性琥珀,其余灰)。
+ * 非持仓的 hold → 观望、非持仓的 add → 建仓(与 Opportunities 的 displayActionLabel 对齐)。
+ */
+function actionVisual(item: StrategySignalItem): { label: string; color: string } {
+  const key = (item.action || '').toLowerCase()
+  let label = item.action_label || item.action || '观望'
+  if (!item.is_holding_snapshot && key === 'hold') label = '观望'
+  if (!item.is_holding_snapshot && key === 'add') label = '建仓'
+  if (key === 'buy' || key === 'add') return { label, color: UP }
+  if (key === 'hold') return { label, color: NEUTRAL }
+  return { label, color: SLATE }
+}
+
+/** AI 评分(1~10)分档配色:≥8 红(强)、6~8 琥珀、<6 灰。 */
+function scoreColor(score: number): string {
+  if (score >= 8) return UP
+  if (score >= 6) return NEUTRAL
+  return SLATE
+}
+
+function FactorList({
+  title,
+  color,
+  bg,
+  border,
+  items,
+  sign,
+}: {
+  title: string
+  color: string
+  bg: string
+  border: string
+  items: { label: string; contribution: number }[]
+  sign: '+' | '-'
+}) {
+  if (!items.length) return null
+  return (
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ fontSize: 13, fontWeight: 700, color, marginBottom: 8 }}>{title}</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {items.map((f, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              background: bg,
+              border: `1px solid ${border}`,
+              borderRadius: 8,
+              padding: '7px 10px',
+              fontSize: 12.5,
+            }}
+          >
+            <span style={{ color: '#334155', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {f.label}
+            </span>
+            <span style={{ color, fontWeight: 800, flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+              {sign}
+              {Math.abs(f.contribution).toFixed(1)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 个股 AI 评分卡。Hero=AI 评分 X/10 + 操作标签 + 标的;下方利好/风险因子来自 factor_explain。
+ */
+export default function SignalScoreShareCard({ open, onClose, item }: SignalScoreShareCardProps) {
+  const av = actionVisual(item)
+  const aiScore = typeof item.ai_score === 'number' ? item.ai_score : null
+  const heroColor = aiScore != null ? scoreColor(aiScore) : SLATE
+  const name = item.stock_name || item.stock_symbol
+  const positive = (item.factor_explain?.positive ?? []).slice(0, 4)
+  const negative = (item.factor_explain?.negative ?? []).slice(0, 4)
+  const summary = (item.signal || item.reason || '').replace(/\s+/g, ' ').trim()
+
+  return (
+    <ShareCardDialog open={open} onClose={onClose} filename={`AI选股评分-${name}`}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontSize: 22, fontWeight: 800, lineHeight: 1.2, color: '#0f172a' }}>AI 选股评分</div>
+        <div style={{ fontSize: 14, color: '#94a3b8', fontWeight: 500, flexShrink: 0 }}>
+          {marketLabel(item.stock_market)}
+        </div>
+      </div>
+
+      {/* Hero:AI 评分 + 操作标签 + 标的 */}
+      <div
+        style={{
+          marginTop: 18,
+          borderRadius: 18,
+          padding: '22px 24px',
+          background: `linear-gradient(135deg, ${heroColor} 0%, ${heroColor}cc 100%)`,
+          color: '#ffffff',
+          boxShadow: `0 10px 30px -8px ${heroColor}66`,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{ minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 800,
+                lineHeight: 1.2,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {name}
+            </div>
+            <div style={{ fontSize: 13, opacity: 0.9, marginTop: 4, fontVariantNumeric: 'tabular-nums' }}>
+              {item.stock_market}:{item.stock_symbol}
+            </div>
+          </div>
+          <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+            <div style={{ fontSize: 12, opacity: 0.92, fontWeight: 600, letterSpacing: 1 }}>AI 评分</div>
+            <div style={{ fontSize: 44, fontWeight: 900, lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>
+              {aiScore != null ? aiScore : '--'}
+              <span style={{ fontSize: 20, opacity: 0.85 }}> / 10</span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={{
+            marginTop: 14,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            background: 'rgba(255,255,255,0.22)',
+            borderRadius: 999,
+            padding: '5px 14px',
+            fontSize: 14,
+            fontWeight: 700,
+          }}
+        >
+          {av.label}
+        </div>
+      </div>
+
+      {/* 一句话信号 */}
+      {summary && (
+        <div
+          style={{
+            marginTop: 16,
+            fontSize: 14,
+            lineHeight: 1.6,
+            color: '#334155',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {summary}
+        </div>
+      )}
+
+      {/* 因子拆解:利好(绿) / 风险(红) */}
+      {(positive.length > 0 || negative.length > 0) && (
+        <div style={{ marginTop: 18, display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+          <FactorList
+            title="利好因子"
+            color="#059669"
+            bg="#ecfdf5"
+            border="#a7f3d0"
+            items={positive}
+            sign="+"
+          />
+          <FactorList title="风险因子" color="#e11d48" bg="#fff1f2" border="#fecdd3" items={negative} sign="-" />
+        </div>
+      )}
+    </ShareCardDialog>
+  )
+}

--- a/frontend/src/pages/AnalysisDetail.tsx
+++ b/frontend/src/pages/AnalysisDetail.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm'
 import {
   ArrowLeft,
   FileDown,
+  ImageDown,
   List,
   ChevronDown,
   Target,
@@ -24,6 +25,7 @@ import {
 } from '@panwatch/api'
 import { Switch } from '@panwatch/base-ui/components/ui/switch'
 import { buildAnalysisSections } from '@panwatch/biz-ui/analysis-sections'
+import ShareCardModal from '../components/ShareCardModal'
 
 const DECISION_COLOR: Record<string, string> = {
   buy: 'text-rose-500',
@@ -114,6 +116,7 @@ export default function AnalysisDetailPage() {
     }
   })
   const [pdfBusy, setPdfBusy] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
 
   const handleExportPdf = async () => {
     if (pdfBusy) return
@@ -277,9 +280,17 @@ export default function AnalysisDetailPage() {
             <h1 className="text-base font-bold truncate min-w-0">{result.title || `${symbol} 深度分析`}</h1>
             <span className="text-[12px] text-muted-foreground shrink-0">{date}</span>
             <button
+              onClick={() => setShareOpen(true)}
+              className="ml-auto shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/50 text-[12.5px] text-muted-foreground hover:text-foreground hover:bg-accent transition-all"
+              title="生成可分享的结论卡片图"
+            >
+              <ImageDown className="w-3.5 h-3.5" />
+              分享图
+            </button>
+            <button
               onClick={handleExportPdf}
               disabled={pdfBusy}
-              className="ml-auto shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/50 text-[12.5px] text-muted-foreground hover:text-foreground hover:bg-accent transition-all disabled:opacity-50"
+              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/50 text-[12.5px] text-muted-foreground hover:text-foreground hover:bg-accent transition-all disabled:opacity-50"
               title="导出 PDF 文件"
             >
               <FileDown className="w-3.5 h-3.5" />
@@ -458,6 +469,15 @@ export default function AnalysisDetailPage() {
           </div>
         </aside>
       </div>
+
+      {/* 分享卡片(导出 PNG) */}
+      <ShareCardModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        result={result}
+        symbol={symbol}
+        date={date}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
-import { RefreshCw, AlertTriangle, Sparkles, Activity, ShieldAlert, Newspaper } from 'lucide-react'
+import { RefreshCw, AlertTriangle, Sparkles, Activity, ShieldAlert, Newspaper, Share2 } from 'lucide-react'
 import {
   dashboardApi,
   portfolioApi,
@@ -25,6 +25,9 @@ import { Button } from '@panwatch/base-ui/components/ui/button'
 import { Onboarding } from '@panwatch/biz-ui/components/onboarding'
 import StockInsightModal from '@panwatch/biz-ui/components/stock-insight-modal'
 import DiscoveryPanel from '@/components/DiscoveryPanel'
+import BenchmarkShareCard from '@/components/BenchmarkShareCard'
+import DiagnosticsShareCard from '@/components/DiagnosticsShareCard'
+import DigestShareCard from '@/components/DigestShareCard'
 
 function pct(v?: number | null, digits = 2): string {
   if (v == null || !isFinite(v)) return '--'
@@ -69,6 +72,10 @@ export default function DashboardPage() {
   const [aiReviewLoading, setAiReviewLoading] = useState(false)
   const [brief, setBrief] = useState<DashboardBrief | null>(null)
   const [briefOpen, setBriefOpen] = useState(false)
+  // 分享卡开关:成绩单(基准)/ 组合体检 / 每日 digest
+  const [shareBench, setShareBench] = useState(false)
+  const [shareDiag, setShareDiag] = useState(false)
+  const [shareDigest, setShareDigest] = useState(false)
   const [showOnboarding, setShowOnboarding] = useState(false)
   const [modal, setModal] = useState<{ open: boolean; symbol: string; market: string; name: string; hasPosition: boolean }>({
     open: false,
@@ -209,6 +216,12 @@ export default function DashboardPage() {
     return rows.filter((x): x is CurateCandidate & { why: string } => !!x)
   }, [curated, candidates])
 
+  const today = useMemo(() => {
+    const d = new Date()
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    const dd = String(d.getDate()).padStart(2, '0')
+    return `${d.getFullYear()}-${mm}-${dd}`
+  }, [])
   const hasHoldings = (diag?.position_count ?? 0) > 0
   const benchReady = bench && !bench.empty && bench.excess_return != null
   const hasWatchlist = (overview?.kpis?.watchlist_count ?? 0) > 0
@@ -258,6 +271,17 @@ export default function DashboardPage() {
           <Activity className="h-4 w-4 text-primary" />
           <h2 className="text-sm font-semibold">今日要紧事</h2>
           <span className="text-[11px] text-muted-foreground">你的持仓/自选里今天该关注的</span>
+          {feed.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShareDigest(true)}
+              className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-primary"
+              title="生成今日盯盘分享图"
+            >
+              <Share2 className="h-3.5 w-3.5" />
+              分享图
+            </button>
+          )}
         </div>
         {loading && candidates.length === 0 ? (
           <div className="py-6 text-center text-[12px] text-muted-foreground">扫描中…</div>
@@ -312,6 +336,28 @@ export default function DashboardPage() {
           <div className="mb-2 flex items-center gap-2">
             <ShieldAlert className="h-4 w-4 text-primary" />
             <h2 className="text-sm font-semibold">组合体检</h2>
+            {benchReady && (
+              <button
+                type="button"
+                onClick={() => setShareBench(true)}
+                className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-primary"
+                title="生成模拟盘成绩单分享图"
+              >
+                <Share2 className="h-3.5 w-3.5" />
+                成绩单
+              </button>
+            )}
+            {hasHoldings && (
+              <button
+                type="button"
+                onClick={() => setShareDiag(true)}
+                className={`${benchReady ? '' : 'ml-auto'} inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-primary`}
+                title="生成组合体检分享图"
+              >
+                <Share2 className="h-3.5 w-3.5" />
+                体检图
+              </button>
+            )}
           </div>
           {!hasHoldings ? (
             <div className="py-6 text-center text-[12px] text-muted-foreground">
@@ -463,6 +509,37 @@ export default function DashboardPage() {
         stockName={modal.name}
         hasPosition={modal.hasPosition}
       />
+
+      {/* 分享卡:模拟盘成绩单(vs 基准) */}
+      {shareBench && bench && (
+        <BenchmarkShareCard open={shareBench} onClose={() => setShareBench(false)} bench={bench} />
+      )}
+
+      {/* 分享卡:组合体检(脱敏,无金额) */}
+      {shareDiag && diag && (
+        <DiagnosticsShareCard
+          open={shareDiag}
+          onClose={() => setShareDiag(false)}
+          diag={diag}
+          excessReturn={benchReady ? bench!.excess_return : null}
+          benchmarkLabel={bench?.benchmark_label}
+        />
+      )}
+
+      {/* 分享卡:今日盯盘 digest */}
+      <DigestShareCard
+        open={shareDigest}
+        onClose={() => setShareDigest(false)}
+        date={today}
+        items={feed.map((it) => ({
+          type: it.type,
+          name: it.name,
+          symbol: it.symbol,
+          why: it.why,
+          change_pct: it.change_pct ?? null,
+        }))}
+      />
+
       <Onboarding open={showOnboarding} onComplete={handleOnboardingComplete} hasStocks={hasWatchlist} />
     </div>
   )

--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, RefreshCw, Sparkles } from 'lucide-react'
+import { AlertTriangle, RefreshCw, Share2, Sparkles } from 'lucide-react'
 import {
   recommendationsApi,
   stocksApi,
@@ -13,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useLocalStorage } from '@/lib/utils'
 import StockInsightModal from '@panwatch/biz-ui/components/stock-insight-modal'
 import FactorWeightsPanel from '@/components/FactorWeightsPanel'
+import SignalScoreShareCard from '@/components/SignalScoreShareCard'
 
 type SourceFilter = 'all' | 'market_scan' | 'watchlist' | 'mixed'
 type HoldingFilter = 'all' | 'held' | 'unheld'
@@ -242,6 +243,9 @@ export default function OpportunitiesPage() {
   const [insightMarket, setInsightMarket] = useState('CN')
   const [insightName, setInsightName] = useState<string | undefined>(undefined)
   const [insightHasPosition, setInsightHasPosition] = useState(false)
+
+  // 个股 AI 评分分享卡:当前分享的信号
+  const [shareSignal, setShareSignal] = useState<StrategySignalItem | null>(null)
 
   const openInsight = useCallback((item: StrategySignalItem) => {
     setInsightSymbol(item.stock_symbol)
@@ -802,7 +806,18 @@ export default function OpportunitiesPage() {
                 <div className="text-[10px] text-muted-foreground">
                   来源: {sourceFlags.join(' + ')}
                 </div>
-                <div className="text-[10px] text-muted-foreground">评估: 自动后验</div>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setShareSignal(item)}
+                    className="inline-flex items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-primary"
+                    title="生成 AI 评分分享图"
+                  >
+                    <Share2 className="h-3 w-3" />
+                    分享图
+                  </button>
+                  <div className="text-[10px] text-muted-foreground">评估: 自动后验</div>
+                </div>
               </div>
             </div>
           )
@@ -831,6 +846,14 @@ export default function OpportunitiesPage() {
         stockName={insightName}
         hasPosition={insightHasPosition}
       />
+
+      {shareSignal && (
+        <SignalScoreShareCard
+          open={!!shareSignal}
+          onClose={() => setShareSignal(null)}
+          item={shareSignal}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 分享卡体系

把 PanWatch 的关键产出一键导成**带品牌水印的 PNG**,发雪球/群引流(github.com/TNT-Likely/PanWatch)。纯前端 html-to-image,无后端/无公开接口。

### 共享基建
`ShareCardDialog`:统一品牌 footer + 仅供参考免责 + 预览弹窗 + toPng 导出(2x);各卡只写卡面。

### 5 张卡
- **TA 深度分析卡**:5 档评级 + 置信度 + 一句话结论(清洗 markdown)
- **模拟盘成绩单卡(vs 基准)**:超额/信息比率/相对回撤 + 净值 sparkline(**脱敏只 %**)
- **个股 AI 评分卡**:1–10 + 红绿因子(机会页每条信号)
- **组合体检卡**:HHI/最大单仓/市场分布/风险提示(**脱敏不显金额**)
- **每日 digest 卡**:今日要紧事 highlights

### 入口
详情页(TA)· Dashboard(成绩单/体检/digest)· 机会页(每条信号评分)。A股红绿配色;前端 build 过。