### PR TITLE
feat: AI 服务商模型自动嗅探(/v1/models)、批量添加与测试 temperature 兼容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 # Claude
 .claude/
 *.tsbuildinfo
+
+# 本地设计/计划文档,不入库
+docs/superpowers/

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Check, Eye, EyeOff, Plus, Pencil, Trash2, Star, Send, Cpu, Play, Download, Upload, FileJson, BarChart3, User } from 'lucide-react'
+import { Check, Eye, EyeOff, Plus, Pencil, Trash2, Star, Send, Cpu, Play, Download, Upload, FileJson, BarChart3, User, Radar } from 'lucide-react'
 import { fetchAPI, type AIService, type AIModel, type NotifyChannel } from '@panwatch/api'
 import { useAvatar, saveAvatar, fileToAvatarDataUrl } from '@/hooks/use-avatar'
 import { Input } from '@panwatch/base-ui/components/ui/input'
@@ -161,6 +161,15 @@ export default function SettingsPage() {
   const [modelDialogOpen, setModelDialogOpen] = useState(false)
   const [modelForm, setModelForm] = useState<ModelForm>(emptyModelForm)
   const [editModelId, setEditModelId] = useState<number | null>(null)
+
+  // 批量选择嗅探到的模型
+  const [batchOpen, setBatchOpen] = useState(false)
+  const [batchServiceId, setBatchServiceId] = useState<number | null>(null)
+  const [batchCandidates, setBatchCandidates] = useState<string[]>([])
+  const [batchChecked, setBatchChecked] = useState<Set<string>>(new Set())
+  const [batchDefault, setBatchDefault] = useState<string>('')
+  const [submittingBatch, setSubmittingBatch] = useState(false)
+  const [discoveringService, setDiscoveringService] = useState<number | null>(null)
 
   // Channel dialog
   const [channelDialogOpen, setChannelDialogOpen] = useState(false)
@@ -377,15 +386,93 @@ export default function SettingsPage() {
 
   const saveService = async () => {
     try {
+      let serviceId = editServiceId
       if (editServiceId) {
         await fetchAPI(`/providers/services/${editServiceId}`, { method: 'PUT', body: JSON.stringify(serviceForm) })
       } else {
-        await fetchAPI('/providers/services', { method: 'POST', body: JSON.stringify(serviceForm) })
+        const created = await fetchAPI<AIService>('/providers/services', { method: 'POST', body: JSON.stringify(serviceForm) })
+        serviceId = created.id
       }
       setServiceDialogOpen(false)
-      load()
+      await load()
+      if (!editServiceId && serviceId) {
+        try {
+          const res = await fetchAPI<{ models: string[] }>(
+            `/providers/services/${serviceId}/discover-models`,
+            { method: 'POST' },
+          )
+          const found = res.models.filter(Boolean)
+          if (found.length > 0) {
+            setBatchServiceId(serviceId)
+            setBatchCandidates(found)
+            setBatchChecked(new Set())
+            setBatchDefault('')
+            setBatchOpen(true)
+          } else {
+            toast('服务商已保存，未自动发现模型，可手动添加', 'info')
+          }
+        } catch (e) {
+          toast(
+            e instanceof Error
+              ? `服务商已保存，自动嗅探失败：${e.message}，可手动添加模型`
+              : '服务商已保存，该服务商暂不支持自动嗅探，可手动添加模型',
+            'info',
+          )
+        }
+      }
     } catch (e) {
       toast(e instanceof Error ? e.message : '保存失败', 'error')
+    }
+  }
+
+  // 手动对某服务商嗅探并打开批量选择框(排除已添加的模型)
+  const discoverForService = async (serviceId: number) => {
+    setDiscoveringService(serviceId)
+    try {
+      const res = await fetchAPI<{ models: string[] }>(
+        `/providers/services/${serviceId}/discover-models`,
+        { method: 'POST' },
+      )
+      const svc = services.find(s => s.id === serviceId)
+      const added = new Set((svc?.models || []).map(m => m.model))
+      const found = res.models.filter(Boolean).filter(id => !added.has(id))
+      if (found.length === 0) {
+        toast('未发现可新增的模型', 'info')
+        return
+      }
+      setBatchServiceId(serviceId)
+      setBatchCandidates(found)
+      setBatchChecked(new Set())
+      setBatchDefault('')
+      setBatchOpen(true)
+    } catch (e) {
+      toast(e instanceof Error ? e.message : '该服务商暂不支持自动嗅探', 'error')
+    } finally {
+      setDiscoveringService(null)
+    }
+  }
+
+  const submitBatchModels = async () => {
+    if (!batchServiceId) return
+    const models = Array.from(batchChecked).map(m => ({
+      name: '',
+      model: m,
+      is_default: m === batchDefault,
+    }))
+    if (models.length === 0) { setBatchOpen(false); return }
+    setSubmittingBatch(true)
+    try {
+      await fetchAPI(`/providers/services/${batchServiceId}/models/batch`, {
+        method: 'POST',
+        body: JSON.stringify({ models }),
+      })
+      setBatchOpen(false)
+      toast(`已添加 ${models.length} 个模型`, 'success')
+      load()
+    } catch (e) {
+      toast(e instanceof Error ? e.message : '批量添加失败', 'error')
+    } finally {
+      setSubmittingBatch(false)
     }
   }
 
@@ -676,6 +763,14 @@ export default function SettingsPage() {
                     <div className="flex items-center gap-1 flex-shrink-0">
                       <Button size="sm" variant="ghost" className="h-7 text-[11px]" onClick={() => openModelDialog(svc.id)}>
                         <Plus className="w-3 h-3" /> 模型
+                      </Button>
+                      <Button
+                        variant="ghost" size="icon" className="h-7 w-7"
+                        title="嗅探模型（自动发现可用模型）"
+                        disabled={discoveringService === svc.id}
+                        onClick={() => discoverForService(svc.id)}
+                      >
+                        <Radar className={`w-3.5 h-3.5 ${discoveringService === svc.id ? 'animate-pulse' : ''}`} />
                       </Button>
                       <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openServiceDialog(svc)}>
                         <Pencil className="w-3.5 h-3.5" />
@@ -1089,11 +1184,12 @@ export default function SettingsPage() {
               />
             </div>
             <div>
-              <Label>模型标识</Label>
+              <Label>模型标识 <span className="text-muted-foreground font-normal">(可用服务商上的「嗅探」批量发现)</span></Label>
               <Input
                 value={modelForm.model}
+                disabled={!modelForm.service_id}
                 onChange={e => setModelForm({ ...modelForm, model: e.target.value })}
-                placeholder="gpt-4o / glm-4-flash"
+                placeholder={modelForm.service_id ? 'gpt-4o / glm-4-flash' : '请先选择服务商'}
                 className="font-mono"
               />
             </div>
@@ -1103,6 +1199,80 @@ export default function SettingsPage() {
                 {editModelId ? '保存' : '创建'}
               </Button>
             </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 批量选择嗅探到的模型 */}
+      <Dialog open={batchOpen} onOpenChange={setBatchOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>发现 {batchCandidates.length} 个模型</DialogTitle>
+            <DialogDescription>勾选要添加的模型，并可指定一个默认模型</DialogDescription>
+          </DialogHeader>
+          <div className="mt-3 flex items-center justify-between px-0.5 text-xs text-muted-foreground">
+            <span>已选 <span className="font-mono text-foreground">{batchChecked.size}</span> / {batchCandidates.length}</span>
+            <button
+              type="button"
+              className="hover:text-foreground"
+              onClick={() => setBatchChecked(
+                batchChecked.size === batchCandidates.length ? new Set() : new Set(batchCandidates),
+              )}
+            >
+              {batchChecked.size === batchCandidates.length ? '取消全选' : '全选'}
+            </button>
+          </div>
+          <div className="mt-1.5 max-h-80 space-y-1.5 overflow-y-auto scrollbar pr-1">
+            {batchCandidates.map(id => {
+              const checked = batchChecked.has(id)
+              const isDefault = batchDefault === id
+              return (
+                <div
+                  key={id}
+                  onClick={() => {
+                    const next = new Set(batchChecked)
+                    if (checked) { next.delete(id); if (isDefault) setBatchDefault('') }
+                    else next.add(id)
+                    setBatchChecked(next)
+                  }}
+                  className={`flex cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-colors ${
+                    checked ? 'border-primary/60 bg-primary/10' : 'border-border/50 hover:border-border hover:bg-muted/40'
+                  }`}
+                >
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <span className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                      checked ? 'border-primary bg-primary text-primary-foreground' : 'border-muted-foreground/40'
+                    }`}>
+                      {checked && <Check className="h-3 w-3" strokeWidth={3} />}
+                    </span>
+                    <span className="truncate font-mono text-sm">{id}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={e => {
+                      e.stopPropagation()
+                      if (isDefault) { setBatchDefault('') }
+                      else {
+                        setBatchDefault(id)
+                        if (!checked) { const next = new Set(batchChecked); next.add(id); setBatchChecked(next) }
+                      }
+                    }}
+                    className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors ${
+                      isDefault ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    }`}
+                  >
+                    <Star className={`h-3 w-3 ${isDefault ? 'fill-current' : ''}`} />
+                    {isDefault ? '默认' : '设默认'}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={() => setBatchOpen(false)}>跳过</Button>
+            <Button onClick={submitBatchModels} disabled={batchChecked.size === 0 || submittingBatch}>
+              {submittingBatch ? '添加中…' : `添加 ${batchChecked.size} 个`}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/core/ai_client.py
+++ b/src/core/ai_client.py
@@ -30,7 +30,7 @@ class AIClient:
         system_prompt: str,
         user_content: str,
         images: list[str] | None = None,
-        temperature: float = 0.4,
+        temperature: float | None = 0.4,
     ) -> str:
         """
         调用 LLM 获取文本回复。
@@ -60,11 +60,10 @@ class AIClient:
             messages.append({"role": "user", "content": user_content})
 
         try:
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                temperature=temperature,
-            )
+            create_kwargs = {"model": self.model, "messages": messages}
+            if temperature is not None:
+                create_kwargs["temperature"] = temperature
+            response = await self.client.chat.completions.create(**create_kwargs)
             # 记录 token 用量
             if response.usage:
                 self.total_tokens_used += response.usage.total_tokens

--- a/src/core/ai_client.py
+++ b/src/core/ai_client.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class AIClient:
     """OpenAI 协议兼容的 AI 客户端"""
 
-    def __init__(self, base_url: str, api_key: str, model: str, proxy: str = ""):
+    def __init__(self, base_url: str, api_key: str, model: str = "", proxy: str = ""):
         kwargs = {
             "base_url": base_url,
             "api_key": api_key,
@@ -128,6 +128,11 @@ class AIClient:
         except Exception as e:
             logger.error(f"AI tool use 调用失败: {e}")
             raise
+
+    async def list_models(self) -> list[str]:
+        """通过 OpenAI 兼容的 /v1/models 拉取可用模型 id 列表。"""
+        resp = await self.client.models.list()
+        return sorted(m.id for m in resp.data)
 
     def _encode_image(self, image_path: str) -> str | None:
         """将图片文件编码为 base64"""

--- a/src/web/api/providers.py
+++ b/src/web/api/providers.py
@@ -191,10 +191,12 @@ async def test_model(model_id: int, db: Session = Depends(get_db)):
             api_key=service.api_key,
             model=model.model,
         )
+        # 测试连通性时不下发 temperature:部分模型(如 o1/claude-opus 等)不接受该参数,
+        # 省略后对所有模型都安全,避免因 temperature 报错而误判模型不可用。
         reply = await client.chat(
             system_prompt="You are a helpful assistant.",
             user_content="Say 'OK' in one word.",
-            temperature=0,
+            temperature=None,
         )
         return {"ok": True, "reply": reply.strip()}
     except Exception as e:

--- a/src/web/api/providers.py
+++ b/src/web/api/providers.py
@@ -113,6 +113,16 @@ class ModelUpdate(BaseModel):
     is_default: bool | None = None
 
 
+class BatchModelItem(BaseModel):
+    name: str = ""
+    model: str
+    is_default: bool = False
+
+
+class BatchModelCreate(BaseModel):
+    models: list[BatchModelItem] = []
+
+
 @router.get("/models", response_model=list[ModelResponse])
 def list_models(db: Session = Depends(get_db)):
     return db.query(AIModel).order_by(AIModel.id).all()
@@ -189,3 +199,41 @@ async def test_model(model_id: int, db: Session = Depends(get_db)):
         return {"ok": True, "reply": reply.strip()}
     except Exception as e:
         raise HTTPException(400, f"测试失败: {e}")
+
+
+@router.post("/services/{service_id}/discover-models")
+async def discover_models(service_id: int, db: Session = Depends(get_db)):
+    service = db.query(AIService).filter(AIService.id == service_id).first()
+    if not service:
+        raise HTTPException(404, "AI 服务商不存在")
+    try:
+        client = AIClient(base_url=service.base_url, api_key=service.api_key)
+        models = await client.list_models()
+        return {"models": models}
+    except Exception as e:
+        raise HTTPException(400, f"嗅探失败: {e}")
+
+
+@router.post("/services/{service_id}/models/batch")
+def batch_add_models(service_id: int, body: BatchModelCreate, db: Session = Depends(get_db)):
+    service = db.query(AIService).filter(AIService.id == service_id).first()
+    if not service:
+        raise HTTPException(404, "AI 服务商不存在")
+
+    existing = {m.model for m in service.models}
+    added = 0
+    for item in body.models:
+        if not item.model or item.model in existing:
+            continue
+        if item.is_default:
+            db.query(AIModel).update({"is_default": False})
+        db.add(AIModel(
+            name=item.name or item.model,
+            service_id=service_id,
+            model=item.model,
+            is_default=item.is_default,
+        ))
+        existing.add(item.model)
+        added += 1
+    db.commit()
+    return {"added": added}

--- a/tests/test_ai_provider_sniff.py
+++ b/tests/test_ai_provider_sniff.py
@@ -54,6 +54,38 @@ def test_list_models_returns_sorted_ids():
     assert asyncio.run(client.list_models()) == ["aaa", "gpt-4o"]
 
 
+def test_chat_omits_temperature_when_none():
+    """temperature=None 时不向 create 下发该字段。"""
+    client = _make_client()
+    seen: dict = {}
+
+    async def _fake_create(**kwargs):
+        seen.update(kwargs)
+        msg = type("Msg", (), {"content": "ok"})()
+        choice = type("C", (), {"message": msg})()
+        return type("Resp", (), {"usage": None, "choices": [choice]})()
+
+    client.client.chat.completions.create = _fake_create
+    asyncio.run(client.chat("s", "u", temperature=None))
+    assert "temperature" not in seen
+
+
+def test_chat_sends_temperature_when_float():
+    """temperature 为数值时正常下发。"""
+    client = _make_client()
+    seen: dict = {}
+
+    async def _fake_create(**kwargs):
+        seen.update(kwargs)
+        msg = type("Msg", (), {"content": "ok"})()
+        choice = type("C", (), {"message": msg})()
+        return type("Resp", (), {"usage": None, "choices": [choice]})()
+
+    client.client.chat.completions.create = _fake_create
+    asyncio.run(client.chat("s", "u", temperature=0))
+    assert seen["temperature"] == 0
+
+
 def test_discover_models_returns_list(db, monkeypatch):
     """discover-models 用服务商凭证嗅探并返回模型 id 列表。"""
     from src.web.api import providers
@@ -127,6 +159,27 @@ def test_batch_add_skips_duplicates_and_sets_default(db, monkeypatch):
     assert defaults == ["new-a"]
     # 显示名为空的回退为 model 标识
     assert next(m for m in all_models if m.model == "new-b").name == "new-b"
+
+
+def test_test_model_omits_temperature(db, monkeypatch):
+    """测试连通性时不下发 temperature(对不支持该参数的模型也安全)。"""
+    from src.web.api import providers
+
+    m = _seed_service_with_model(db)
+    seen: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        async def chat(self, system_prompt, user_content, temperature=0.4):
+            seen["temperature"] = temperature
+            return "OK"
+
+    monkeypatch.setattr(providers, "AIClient", _FakeClient)
+    res = asyncio.run(providers.test_model(m.id, db))
+    assert res["ok"] is True
+    assert seen["temperature"] is None  # 未带 temperature
 
 
 def test_test_model_error_maps_to_400(db, monkeypatch):

--- a/tests/test_ai_provider_sniff.py
+++ b/tests/test_ai_provider_sniff.py
@@ -1,0 +1,172 @@
+"""AI 服务商模型嗅探 + 测试 temperature 降级 的单元测试。"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.core.ai_client import AIClient
+from src.web import models as _models  # noqa: F401  注册 ORM
+from src.web.database import Base
+from src.web.models import AIService, AIModel
+
+
+@pytest.fixture
+def db():
+    """独立内存 SQLite 会话,建全表。"""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _seed_service_with_model(db) -> AIModel:
+    svc = AIService(name="s", base_url="http://x", api_key="k")
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+    m = AIModel(name="m", service_id=svc.id, model="m", is_default=False)
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    return m
+
+
+def _make_client() -> AIClient:
+    return AIClient(base_url="http://example.test", api_key="k", model="m")
+
+
+def test_list_models_returns_sorted_ids():
+    """list_models 调用 models.list() 并返回排序后的模型 id 列表。"""
+    client = _make_client()
+
+    class _FakeModels:
+        async def list(self):
+            data = [type("M", (), {"id": "gpt-4o"})(), type("M", (), {"id": "aaa"})()]
+            return type("R", (), {"data": data})()
+
+    client.client.models = _FakeModels()
+    assert asyncio.run(client.list_models()) == ["aaa", "gpt-4o"]
+
+
+def test_discover_models_returns_list(db, monkeypatch):
+    """discover-models 用服务商凭证嗅探并返回模型 id 列表。"""
+    from src.web.api import providers
+
+    svc = AIService(name="s", base_url="http://x", api_key="k")
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        async def list_models(self):
+            return ["gpt-4o", "o1"]
+
+    monkeypatch.setattr(providers, "AIClient", _FakeClient)
+    res = asyncio.run(providers.discover_models(svc.id, db))
+    assert res["models"] == ["gpt-4o", "o1"]
+
+
+def test_discover_models_error_maps_to_400(db, monkeypatch):
+    """嗅探失败(服务商不支持/网络错误)返回 400。"""
+    from fastapi import HTTPException
+    from src.web.api import providers
+
+    svc = AIService(name="s", base_url="http://x", api_key="k")
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        async def list_models(self):
+            raise RuntimeError("404 not found")
+
+    monkeypatch.setattr(providers, "AIClient", _FakeClient)
+    try:
+        asyncio.run(providers.discover_models(svc.id, db))
+        assert False, "应抛 HTTPException"
+    except HTTPException as e:
+        assert e.status_code == 400
+
+
+def test_batch_add_skips_duplicates_and_sets_default(db, monkeypatch):
+    """批量新增:跳过已存在的 model 标识,设默认时清零其余。"""
+    from src.web.api import providers
+
+    svc = AIService(name="s", base_url="http://x", api_key="k")
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+    db.add(AIModel(name="exists", service_id=svc.id, model="dup", is_default=True))
+    db.commit()
+
+    body = providers.BatchModelCreate(models=[
+        providers.BatchModelItem(name="", model="dup", is_default=False),   # 重复,跳过
+        providers.BatchModelItem(name="新A", model="new-a", is_default=True),
+        providers.BatchModelItem(name="", model="new-b", is_default=False),
+    ])
+    res = providers.batch_add_models(svc.id, body, db)  # 同步端点(threadpool),不阻塞事件循环
+    assert res["added"] == 2
+
+    all_models = db.query(AIModel).filter(AIModel.service_id == svc.id).all()
+    names = {m.model for m in all_models}
+    assert names == {"dup", "new-a", "new-b"}
+    # new-a 设为默认后,其余(含原 dup)应被清零
+    defaults = [m.model for m in all_models if m.is_default]
+    assert defaults == ["new-a"]
+    # 显示名为空的回退为 model 标识
+    assert next(m for m in all_models if m.model == "new-b").name == "new-b"
+
+
+def test_test_model_error_maps_to_400(db, monkeypatch):
+    """测试调用报错时映射为 400。"""
+    from fastapi import HTTPException
+    from src.web.api import providers
+
+    m = _seed_service_with_model(db)
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        async def chat(self, system_prompt, user_content, temperature=0.4):
+            raise RuntimeError("401 unauthorized")
+
+    monkeypatch.setattr(providers, "AIClient", _FakeClient)
+    try:
+        asyncio.run(providers.test_model(m.id, db))
+        assert False, "应抛 HTTPException"
+    except HTTPException as e:
+        assert e.status_code == 400
+
+
+def test_discover_models_empty_list(db, monkeypatch):
+    """嗅探返回空列表时,接口正常返回空 models。"""
+    from src.web.api import providers
+
+    svc = AIService(name="s", base_url="http://x", api_key="k")
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        async def list_models(self):
+            return []
+
+    monkeypatch.setattr(providers, "AIClient", _FakeClient)
+    res = asyncio.run(providers.discover_models(svc.id, db))
+    assert res["models"] == []


### PR DESCRIPTION
## 概述

围绕「添加 AI 服务商后自动发现/选择模型」与「部分模型测试时 temperature 报错」两个诉求，分两个功能提交：

### feat: 模型自动嗅探(/v1/models) + 批量添加
- `AIClient.list_models()` 通过 OpenAI 兼容 `GET /models` 拉取可用模型；`model` 参数给默认值(仅探测场景可不传)
- 新增 `POST /providers/services/{id}/discover-models`(嗅探)、`POST /providers/services/{id}/models/batch`(批量新增，跳过重复/设默认清零)
- 批量接口用**同步 `def`**(FastAPI 放线程池)——避免 `async def` 阻塞事件循环导致 `SQLite database is locked`
- 前端(Settings)：服务商行加 **Radar 嗅探入口** → 弹出批量选择框(暗色卡片行/勾选/设默认/全选/防重复提交)；新建服务商后自动嗅探

### fix: 测试模型兼容不支持 temperature 的模型
- `AIClient.chat` 的 `temperature` 改为可空，为 `None` 时不下发该字段(`chat_multi`/`chat_with_tools` 不变)
- `test_model` 测试连通性时传 `temperature=None`：部分模型(o1/claude-opus 等)拒绝 temperature 会报 400，省略后对所有模型都安全

## 测试
- 新增 `tests/test_ai_provider_sniff.py`(9 条：list_models / discover / batch / test_model 等)
- 全量 `python -m pytest tests/` → 449 passed, 1 skipped
- 前端 `pnpm build` 通过

## 说明
- 「添加模型」弹窗的模型标识为纯输入框；批量发现走服务商行的嗅探入口
- temperature 降级仅作用在**测试连通性**；真实 agent 调用仍按各自 temperature(如后续发现有模型在 agent 调用中也拒绝 temperature，可再提到 AIClient 全局层)