### PR TITLE
feat(dashboard): 首页视觉改版——补齐图形层(信息架构不动)

### DIFF
--- a/frontend/packages/api/src/dashboard.ts
+++ b/frontend/packages/api/src/dashboard.ts
@@ -23,6 +23,8 @@ export interface DashboardMarketIndex {
   change_pct: number | null
   change_amount: number | null
   prev_close: number | null
+  /** 近20日收盘价,用于首页指数走势 sparkline;取数失败/无映射(如美股指数)则为空数组 */
+  spark?: number[]
 }
 
 export interface DashboardMarketStatus {
@@ -57,6 +59,8 @@ export interface DashboardAccountSummary {
   total_market_value: number
   total_pnl: number
   total_pnl_pct: number
+  /** 今日盈亏(账户内所有持仓 daily_pnl 汇总,元) */
+  total_daily_pnl: number
   total_assets: number
   positions: DashboardPosition[]
 }
@@ -68,6 +72,8 @@ export interface DashboardPortfolioSummary {
     total_cost: number
     total_pnl: number
     total_pnl_pct: number
+    /** 今日盈亏(全账户汇总,元) */
+    total_daily_pnl: number
     available_funds: number
     total_assets: number
   }

--- a/frontend/packages/api/src/portfolio.ts
+++ b/frontend/packages/api/src/portfolio.ts
@@ -39,12 +39,12 @@ export const portfolioApi = {
   benchmark: (params?: { days?: number; benchmark?: string }) =>
     fetchAPI<PortfolioBenchmark>(
       `/portfolio/benchmark?days=${params?.days ?? 60}&benchmark=${encodeURIComponent(params?.benchmark ?? '000300')}`,
-      { timeoutMs: 40000 },
+      { timeoutMs: 60000 },
     ),
 
   /** 个股对组合收益的贡献(谁拖累/贡献)。 */
   attribution: (days = 60) =>
-    fetchAPI<{ items: AttributionItem[] }>(`/portfolio/attribution?days=${days}`, { timeoutMs: 40000 }),
+    fetchAPI<{ items: AttributionItem[] }>(`/portfolio/attribution?days=${days}`, { timeoutMs: 60000 }),
 
   /** 组合 AI 体检(叙述结论 + 调仓建议)。 */
   aiReview: () => fetchAPI<PortfolioAiReview>('/portfolio/ai-review', { method: 'POST', timeoutMs: 60000 }),

--- a/frontend/src/components/BenchChart.tsx
+++ b/frontend/src/components/BenchChart.tsx
@@ -1,0 +1,154 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+import type { BenchmarkCurvePoint } from '@panwatch/api'
+
+interface BenchChartProps {
+  curve: BenchmarkCurvePoint[]
+  height?: number
+  className?: string
+}
+
+// 3 条内部参考线(均匀分布,非顶/底边框线)
+const GRID_FRACS = [0.2, 0.5, 0.8]
+
+function BenchChartSvg({
+  points,
+  width,
+  height,
+}: {
+  points: BenchmarkCurvePoint[]
+  width: number
+  height: number
+}) {
+  const padLeft = 2
+  const padRight = 40 // 预留右侧 % 刻度文字
+  const padTop = 12
+  const padBottom = 12
+  const innerW = Math.max(10, width - padLeft - padRight)
+  const innerH = Math.max(10, height - padTop - padBottom)
+
+  const allVals: number[] = []
+  for (const p of points) {
+    allVals.push(p.portfolio, p.benchmark)
+  }
+  let min = Math.min(...allVals)
+  let max = Math.max(...allVals)
+  if (max - min < 1e-6) {
+    max += 1
+    min -= 1
+  }
+
+  const n = points.length
+  const xAt = (i: number) => padLeft + (innerW * i) / (n - 1)
+  const yAt = (v: number) => padTop + innerH - (innerH * (v - min)) / (max - min)
+
+  const portfolioPts = points.map((p, i) => [xAt(i), yAt(p.portfolio)] as const)
+  const benchmarkPts = points.map((p, i) => [xAt(i), yAt(p.benchmark)] as const)
+  const portfolioAttr = portfolioPts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
+  const benchmarkAttr = benchmarkPts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
+  const [x0, y0] = portfolioPts[0]
+  const [xN, yN] = portfolioPts[n - 1]
+  const baseline = padTop + innerH
+  const areaAttr = `${xAt(0).toFixed(1)},${baseline.toFixed(1)} ${portfolioAttr} ${xAt(n - 1).toFixed(1)},${baseline.toFixed(1)}`
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} role="img" aria-label="组合净值 vs 基准走势图">
+      <defs>
+        <linearGradient id="benchchart-area" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity={0.22} />
+          <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+
+      {/* 网格线 + 右侧 % 刻度(以曲线起点=100 为基准的累计收益率) */}
+      {GRID_FRACS.map((frac) => {
+        const y = padTop + innerH * frac
+        const v = min + (max - min) * (1 - frac)
+        const pctVal = v - 100
+        const label = `${pctVal >= 0 ? '+' : ''}${pctVal.toFixed(1)}%`
+        return (
+          <g key={frac}>
+            <line
+              x1={padLeft}
+              x2={padLeft + innerW}
+              y1={y}
+              y2={y}
+              stroke="hsl(var(--border))"
+              strokeWidth={1}
+              strokeDasharray="4 4"
+            />
+            <text
+              x={padLeft + innerW + 6}
+              y={y}
+              dominantBaseline="middle"
+              fontSize={10}
+              fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+              fill="hsl(var(--muted-foreground))"
+            >
+              {label}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* 基准:虚线(中性色) */}
+      <polyline
+        points={benchmarkAttr}
+        fill="none"
+        stroke="hsl(var(--muted-foreground))"
+        strokeWidth={1.5}
+        strokeDasharray="5 4"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+
+      {/* 组合:实线 + 浅面积(主角) */}
+      <polygon points={areaAttr} fill="url(#benchchart-area)" stroke="none" />
+      <polyline
+        points={portfolioAttr}
+        fill="none"
+        stroke="hsl(var(--primary))"
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+
+      {/* 两端点圆(组合线起止) */}
+      <circle cx={x0} cy={y0} r={4} fill="hsl(var(--card))" />
+      <circle cx={x0} cy={y0} r={2.5} fill="hsl(var(--primary))" />
+      <circle cx={xN} cy={yN} r={4} fill="hsl(var(--card))" />
+      <circle cx={xN} cy={yN} r={2.5} fill="hsl(var(--primary))" />
+    </svg>
+  )
+}
+
+/**
+ * 组合净值 vs 基准 双线图,无第三方图表库依赖。
+ * 组合(primary)实线+浅面积、基准虚线(中性色)、3条虚网格线 + 右侧 % 刻度、组合线两端点圆。
+ * 用容器 clientWidth(ResizeObserver 实测)而非 CSS 缩放渲染 SVG,保证轴文字/线宽不随宽度变化而变形。
+ * curve 为空/有效点数 < 2 时不渲染(由上层负责展示"计算中"等占位文案)。
+ */
+export default function BenchChart({ curve, height = 150, className }: BenchChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => setWidth(el.clientWidth)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const points = (curve || []).filter(
+    (p) => Number.isFinite(p.portfolio) && Number.isFinite(p.benchmark),
+  )
+  if (points.length < 2) return null
+
+  return (
+    <div ref={containerRef} className={className} style={{ width: '100%', height }}>
+      {width > 0 && <BenchChartSvg points={points} width={width} height={height} />}
+    </div>
+  )
+}

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,88 @@
+import { useId } from 'react'
+
+interface SparklineProps {
+  /** 数值序列(如近20日收盘价/净值),自动 min-max 归一到画布高度 */
+  data: number[]
+  width?: number
+  height?: number
+  /** 线条颜色,支持 currentColor 或任意 CSS 颜色(含 hsl(var(--xx))),亮暗主题都可读 */
+  stroke?: string
+  /** 传入则渲染渐变面积(顶部半透明 → 底部透明);不传则只画线 */
+  fill?: string
+  className?: string
+}
+
+/**
+ * 极简走势线,无第三方图表库依赖:SVG polyline + 可选渐变面积 + 尾端点圆。
+ * 用 viewBox 精确匹配 width/height 并配合 preserveAspectRatio="none" + width="100%"
+ * 让父容器控制实际渲染宽度;线宽用 vector-effect="non-scaling-stroke" 避免横向拉伸变形。
+ */
+export default function Sparkline({
+  data,
+  width = 100,
+  height = 28,
+  stroke = 'currentColor',
+  fill,
+  className,
+}: SparklineProps) {
+  const gradId = useId()
+  const vals = (data || []).filter((v) => typeof v === 'number' && Number.isFinite(v))
+  if (vals.length < 2) return null
+
+  let min = Math.min(...vals)
+  let max = Math.max(...vals)
+  if (max - min < 1e-9) {
+    const pad = Math.abs(max) * 0.02 || 1
+    max += pad
+    min -= pad
+  }
+
+  const n = vals.length
+  const padY = Math.max(1.5, height * 0.12)
+  const innerH = height - padY * 2
+  const xAt = (i: number) => (width * i) / (n - 1)
+  const yAt = (v: number) => padY + innerH - (innerH * (v - min)) / (max - min)
+  const points = vals.map((v, i) => [xAt(i), yAt(v)] as const)
+  const pointsAttr = points.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ')
+  const [lastX, lastY] = points[n - 1]
+  const fillColor = fill || stroke
+  const gradientId = `spark-fill-${gradId.replace(/[^a-zA-Z0-9_-]/g, '')}`
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      width="100%"
+      height={height}
+      className={className}
+      role="img"
+      aria-hidden="true"
+    >
+      {fill && (
+        <>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={fillColor} stopOpacity={0.32} />
+              <stop offset="100%" stopColor={fillColor} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <polygon
+            points={`${xAt(0).toFixed(2)},${height} ${pointsAttr} ${xAt(n - 1).toFixed(2)},${height}`}
+            fill={`url(#${gradientId})`}
+            stroke="none"
+          />
+        </>
+      )}
+      <polyline
+        points={pointsAttr}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle cx={lastX} cy={lastY} r={2.2} fill={stroke} />
+    </svg>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,8 +8,10 @@ import {
   recommendationsApi,
   homeApi,
   type DashboardMarketIndex,
+  type DashboardMarketStatus,
   type DashboardMonitorStock,
   type DashboardOverviewResponse,
+  type DashboardPortfolioSummary,
   type PortfolioDiagnostics,
   type PortfolioBenchmark,
   type StrategySignalItem,
@@ -25,6 +27,8 @@ import { Button } from '@panwatch/base-ui/components/ui/button'
 import { Onboarding } from '@panwatch/biz-ui/components/onboarding'
 import StockInsightModal from '@panwatch/biz-ui/components/stock-insight-modal'
 import DiscoveryPanel from '@/components/DiscoveryPanel'
+import Sparkline from '@/components/Sparkline'
+import BenchChart from '@/components/BenchChart'
 import BenchmarkShareCard from '@/components/BenchmarkShareCard'
 import DiagnosticsShareCard from '@/components/DiagnosticsShareCard'
 import DigestShareCard from '@/components/DigestShareCard'
@@ -36,6 +40,38 @@ function pct(v?: number | null, digits = 2): string {
 function moveColor(v?: number | null): string {
   if (v == null) return 'text-muted-foreground'
   return v > 0 ? 'text-rose-500' : v < 0 ? 'text-emerald-500' : 'text-muted-foreground'
+}
+/** 涨跌着色 chip 的背景+文字类;null/平盘 → 灰底。红涨绿跌(A股口径)。 */
+function pctChipCls(v?: number | null): string {
+  if (v == null) return 'bg-accent text-muted-foreground'
+  if (v > 0) return 'bg-rose-500/10 text-rose-500'
+  if (v < 0) return 'bg-emerald-500/10 text-emerald-500'
+  return 'bg-accent text-muted-foreground'
+}
+/** 金额展示:+¥2,175 风格(千分位 + 正负号),脱敏场景外的常规展示用。 */
+function fmtMoney(v?: number | null): string {
+  if (v == null || !isFinite(v)) return '--'
+  const sign = v > 0 ? '+' : v < 0 ? '-' : ''
+  return `${sign}¥${Math.abs(v).toLocaleString('zh-CN', { maximumFractionDigits: 0 })}`
+}
+/** 去掉常见 markdown 标记,供简报摘要行取纯文本用。 */
+function stripMarkdown(s: string): string {
+  return s
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+    .replace(/[#*_>`~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+const WEEKDAY_LABEL = ['日', '一', '二', '三', '四', '五', '六']
+function formatHeaderTime(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${y}-${m}-${day} 周${WEEKDAY_LABEL[d.getDay()]} · ${hh}:${mm} 已刷新`
 }
 const ALERT_LABEL: Record<string, string> = {
   surge: '快速拉升',
@@ -55,6 +91,13 @@ const FEED_BADGE: Record<string, { label: string; cls: string }> = {
   opportunity: { label: '机会', cls: 'bg-primary/10 text-primary' },
 }
 
+// 市场分布 stacked 条配色:CN 用品牌色,US/HK 用差异化色区分
+const MARKET_BAR_CLS: Record<string, string> = {
+  CN: 'bg-primary',
+  US: 'bg-emerald-500',
+  HK: 'bg-orange-500',
+}
+
 export default function DashboardPage() {
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
@@ -72,6 +115,9 @@ export default function DashboardPage() {
   const [aiReviewLoading, setAiReviewLoading] = useState(false)
   const [brief, setBrief] = useState<DashboardBrief | null>(null)
   const [briefOpen, setBriefOpen] = useState(false)
+  const [portfolioSummary, setPortfolioSummary] = useState<DashboardPortfolioSummary | null>(null)
+  const [marketStatus, setMarketStatus] = useState<DashboardMarketStatus[]>([])
+  const [refreshedAt, setRefreshedAt] = useState<Date | null>(null)
   // 分享卡开关:成绩单(基准)/ 组合体检 / 每日 digest
   const [shareBench, setShareBench] = useState(false)
   const [shareDiag, setShareDiag] = useState(false)
@@ -87,14 +133,16 @@ export default function DashboardPage() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    // 快车道:DB/轻量查询,先让首屏(要紧事/指数/体检分布)尽快出来
-    const [idx, sc, ov, dg, ht, td] = await Promise.allSettled([
+    // 快车道:DB/轻量查询,先让首屏(要紧事/指数/体检分布/组合速览)尽快出来
+    const [idx, sc, ov, dg, ht, td, ps, ms] = await Promise.allSettled([
       dashboardApi.indices(),
       dashboardApi.intradayScan(),
       dashboardApi.overview({ market: 'ALL', action_limit: 6, risk_limit: 6 }),
       portfolioApi.diagnostics(),
       homeApi.alertHitsToday(),
       homeApi.todos(),
+      dashboardApi.portfolioSummary(),
+      dashboardApi.marketStatus(),
     ])
     if (idx.status === 'fulfilled') setIndices(idx.value)
     if (sc.status === 'fulfilled') setScan(sc.value.stocks || [])
@@ -102,7 +150,10 @@ export default function DashboardPage() {
     if (dg.status === 'fulfilled') setDiag(dg.value)
     if (ht.status === 'fulfilled') setAlertHits(ht.value)
     if (td.status === 'fulfilled') setTodos(td.value.todos || [])
+    if (ps.status === 'fulfilled') setPortfolioSummary(ps.value)
+    if (ms.status === 'fulfilled') setMarketStatus(ms.value)
     setLoading(false) // 首屏不再等基准/归因(要拉全持仓 K 线)
+    setRefreshedAt(new Date())
 
     // 机会兜底:overview 无机会时再取(不挡首屏)
     if (ov.status !== 'fulfilled' || !ov.value.action_center?.opportunities?.length) {
@@ -230,9 +281,44 @@ export default function DashboardPage() {
       ? (diag.total_unrealized_pnl / (diag.total_market_value - diag.total_unrealized_pnl)) * 100
       : null
 
+  // 今日盈亏(组合速览条 hero):来自 portfolioSummary.total.total_daily_pnl(与 Stocks 页同源字段)
+  const dailyPnl = portfolioSummary?.total?.total_daily_pnl ?? null
+  const dailyPnlPct = useMemo(() => {
+    if (!portfolioSummary || dailyPnl == null) return null
+    const basis = portfolioSummary.total.total_market_value - dailyPnl
+    return basis > 0 ? (dailyPnl / basis) * 100 : null
+  }, [portfolioSummary, dailyPnl])
+  const positionRatioPct = useMemo(() => {
+    if (!portfolioSummary) return null
+    const { total_market_value, total_assets } = portfolioSummary.total
+    return total_assets > 0 ? (total_market_value / total_assets) * 100 : null
+  }, [portfolioSummary])
+  const benchPortfolioSeries = useMemo(() => (bench?.curve || []).map((p) => p.portfolio), [bench])
+
+  // 市场分布 stacked 条的分段(占比降序,过滤掉 0 占比)
+  const marketSegs = useMemo(() => {
+    if (!diag || diag.total_market_value <= 0) return []
+    return Object.entries(diag.by_market)
+      .map(([market, value]) => ({ market, pct: (value / diag.total_market_value) * 100 }))
+      .filter((s) => s.pct > 0.05)
+      .sort((a, b) => b.pct - a.pct)
+  }, [diag])
+
+  // 领涨/拖累双向条的归一基准(取全量 attribution 里最大贡献绝对值,双向对称)
+  const attributionMaxAbs = useMemo(() => {
+    if (attribution.length === 0) return 0
+    return Math.max(...attribution.map((a) => Math.abs(a.contribution_pct)), 0.01)
+  }, [attribution])
+
+  const briefSummary = useMemo(() => {
+    if (!brief?.content) return ''
+    const stripped = stripMarkdown(brief.content)
+    return stripped.length > 120 ? `${stripped.slice(0, 120)}…` : stripped
+  }, [brief])
+
   return (
     <div className="page-container pb-10">
-      {/* 顶部:标题 + 大盘指数细条(降级,不再占主位) */}
+      {/* 顶部:标题 + 刷新 + 日期/市场状态 pills */}
       <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-2">
           <h1 className="text-[20px] font-bold tracking-tight text-foreground md:text-[22px]">今日该看什么</h1>
@@ -240,99 +326,156 @@ export default function DashboardPage() {
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
           </Button>
         </div>
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
-          {hasHoldings && portfolioPnlPct != null && (
-            <span className="flex items-center gap-1">
-              <span className="text-muted-foreground">组合浮盈</span>
-              <span className={`font-mono ${moveColor(portfolioPnlPct)}`}>{pct(portfolioPnlPct)}</span>
-            </span>
-          )}
-          {benchReady && (
-            <span className="flex items-center gap-1">
-              <span className="text-muted-foreground">超额</span>
-              <span className={`font-mono ${moveColor(bench!.excess_return)}`}>{pct(bench!.excess_return)}</span>
-            </span>
-          )}
-          {indices.slice(0, 5).map((ix) => (
-            <span key={`${ix.market}:${ix.symbol}`} className="flex items-center gap-1">
-              <span className="text-muted-foreground">{ix.name}</span>
-              {ix.current_price != null && (
-                <span className="font-mono text-foreground/80">{ix.current_price.toFixed(2)}</span>
-              )}
-              <span className={`font-mono ${moveColor(ix.change_pct)}`}>{pct(ix.change_pct)}</span>
+        <div className="flex flex-wrap items-center gap-2 text-[11px]">
+          {refreshedAt && <span className="text-muted-foreground">{formatHeaderTime(refreshedAt)}</span>}
+          {marketStatus.map((m) => (
+            <span key={m.code} className="inline-flex items-center gap-1.5 rounded-full bg-accent/40 px-2 py-0.5">
+              <span className={`h-1.5 w-1.5 rounded-full ${m.is_trading ? 'bg-amber-500' : 'bg-muted-foreground/40'}`} />
+              <span className="text-muted-foreground">{m.name}</span>
             </span>
           ))}
         </div>
       </div>
 
-      {/* 今日要紧事(主角) */}
+      {/* 组合速览条:今日盈亏 hero + 累计浮盈 + 60日超额 + 仓位% + mini 净值走势 */}
       <div className="card mb-3 p-4">
-        <div className="mb-2 flex items-center gap-2">
-          <Activity className="h-4 w-4 text-primary" />
-          <h2 className="text-sm font-semibold">今日要紧事</h2>
-          <span className="text-[11px] text-muted-foreground">你的持仓/自选里今天该关注的</span>
-          {feed.length > 0 && (
-            <button
-              type="button"
-              onClick={() => setShareDigest(true)}
-              className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-primary"
-              title="生成今日盯盘分享图"
-            >
-              <Share2 className="h-3.5 w-3.5" />
-              分享图
-            </button>
-          )}
-        </div>
-        {loading && candidates.length === 0 ? (
-          <div className="py-6 text-center text-[12px] text-muted-foreground">扫描中…</div>
-        ) : candidates.length === 0 ? (
-          todos.length > 0 ? (
-            <div className="space-y-1.5 py-1">
-              <div className="text-[11px] text-muted-foreground">今日暂无异动/触发 ✓ · 待办:</div>
-              {todos.map((t, i) => (
-                <div
-                  key={i}
-                  className={`flex items-center gap-2 py-1 text-[12px] ${t.symbol ? 'cursor-pointer hover:bg-accent/30' : ''}`}
-                  onClick={() => t.symbol && openStock(t.symbol, t.market || 'CN', '')}
-                >
-                  <span className="shrink-0 rounded bg-amber-500/15 px-1 text-[9px] text-amber-600">
-                    {t.type === 'no_alert' ? '加提醒' : '将到期'}
-                  </span>
-                  <span className="truncate">{t.message}</span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="py-6 text-center text-[12px] text-muted-foreground">今日暂无明显异动或触发信号 ✓</div>
-          )
+        {!hasHoldings ? (
+          <div className="py-4 text-center text-[12px] text-muted-foreground">
+            {loading ? '加载中…' : '暂无持仓,添加持仓后这里展示今日盈亏与组合走势'}
+          </div>
         ) : (
-          <div className="divide-y divide-border/40">
-            {feed.map((it, i) => {
-              const badge = FEED_BADGE[it.type] || { label: it.type, cls: 'bg-accent text-muted-foreground' }
-              return (
-                <div
-                  key={i}
-                  className={`flex items-center gap-3 py-2 ${it.symbol ? 'cursor-pointer hover:bg-accent/30' : ''}`}
-                  onClick={() => it.symbol && openStock(it.symbol, it.market || 'CN', it.name || '')}
-                >
-                  <span className={`shrink-0 rounded px-1 text-[9px] ${badge.cls}`}>{badge.label}</span>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-[13px] font-medium">{it.name || it.symbol}</div>
-                    {it.why && <div className="truncate text-[11px] text-muted-foreground">{it.why}</div>}
-                  </div>
-                  {it.change_pct != null && (
-                    <div className={`shrink-0 font-mono text-[13px] ${moveColor(it.change_pct)}`}>{pct(it.change_pct)}</div>
-                  )}
-                </div>
-              )
-            })}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+            <div>
+              <div className="text-[11px] text-muted-foreground">今日盈亏</div>
+              <div className={`font-mono text-[22px] font-bold leading-tight ${moveColor(dailyPnl)}`}>{fmtMoney(dailyPnl)}</div>
+              {dailyPnlPct != null && <div className={`font-mono text-[11px] ${moveColor(dailyPnlPct)}`}>{pct(dailyPnlPct)}</div>}
+            </div>
+            <div className="hidden h-9 w-px bg-border/60 sm:block" />
+            <div>
+              <div className="text-[11px] text-muted-foreground">累计浮盈</div>
+              <div className={`font-mono text-[14px] ${moveColor(diag!.total_unrealized_pnl)}`}>
+                {fmtMoney(diag!.total_unrealized_pnl)} <span className="text-[11px]">{pct(portfolioPnlPct)}</span>
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] text-muted-foreground">60日超额</div>
+              <div className={`font-mono text-[14px] ${benchReady ? moveColor(bench!.excess_return) : 'text-muted-foreground'}`}>
+                {benchReady ? pct(bench!.excess_return) : '--'}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] text-muted-foreground">仓位</div>
+              <div className="font-mono text-[14px]">{positionRatioPct != null ? `${positionRatioPct.toFixed(0)}%` : '--'}</div>
+            </div>
+            <div className="ml-auto flex items-center gap-3">
+              <div className="w-24">
+                <Sparkline data={benchPortfolioSeries} height={32} className="text-primary" />
+              </div>
+              <button
+                type="button"
+                onClick={() => navigate('/portfolio')}
+                className="shrink-0 text-[11px] text-muted-foreground hover:text-primary"
+              >
+                持仓页 →
+              </button>
+            </div>
           </div>
         )}
       </div>
 
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      {/* 指数走势 pills */}
+      <div className="mb-3 grid grid-cols-2 gap-2.5 md:grid-cols-3 lg:grid-cols-5">
+        {indices.slice(0, 5).map((ix) => (
+          <div key={`${ix.market}:${ix.symbol}`} className="card-subtle relative p-2.5">
+            <div className="flex items-start justify-between gap-1">
+              <div className="min-w-0">
+                <div className="truncate text-[11px] text-muted-foreground">{ix.name}</div>
+                <div className="font-mono text-[15px] text-foreground">
+                  {ix.current_price != null ? ix.current_price.toFixed(2) : '--'}
+                </div>
+              </div>
+              <span className={`shrink-0 rounded px-1 py-0.5 font-mono text-[10px] ${pctChipCls(ix.change_pct)}`}>
+                {ix.change_pct != null ? pct(ix.change_pct) : '--'}
+              </span>
+            </div>
+            {ix.spark && ix.spark.length >= 2 && (
+              <div className="mt-1.5">
+                <Sparkline data={ix.spark} height={26} className={moveColor(ix.change_pct)} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* 主体:要紧事(7) | 体检(5);机会(5) | 简报(7) */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
+        {/* 今日要紧事(主角) */}
+        <div className="card p-4 lg:col-span-7">
+          <div className="mb-2 flex items-center gap-2">
+            <Activity className="h-4 w-4 text-primary" />
+            <h2 className="text-sm font-semibold">今日要紧事</h2>
+            <span className="text-[11px] text-muted-foreground">你的持仓/自选里今天该关注的</span>
+            {feed.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShareDigest(true)}
+                className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-primary"
+                title="生成今日盯盘分享图"
+              >
+                <Share2 className="h-3.5 w-3.5" />
+                分享图
+              </button>
+            )}
+          </div>
+          {loading && candidates.length === 0 ? (
+            <div className="py-6 text-center text-[12px] text-muted-foreground">扫描中…</div>
+          ) : candidates.length === 0 ? (
+            todos.length > 0 ? (
+              <div className="space-y-1.5 py-1">
+                <div className="text-[11px] text-muted-foreground">今日暂无异动/触发 ✓ · 待办:</div>
+                {todos.map((t, i) => (
+                  <div
+                    key={i}
+                    className={`flex items-center gap-2 py-1 text-[12px] ${t.symbol ? 'cursor-pointer hover:bg-accent/30' : ''}`}
+                    onClick={() => t.symbol && openStock(t.symbol, t.market || 'CN', '')}
+                  >
+                    <span className="shrink-0 rounded bg-amber-500/15 px-1 text-[9px] text-amber-600">
+                      {t.type === 'no_alert' ? '加提醒' : '将到期'}
+                    </span>
+                    <span className="truncate">{t.message}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="py-6 text-center text-[12px] text-muted-foreground">今日暂无明显异动或触发信号 ✓</div>
+            )
+          ) : (
+            <div className="divide-y divide-border/40">
+              {feed.map((it, i) => {
+                const badge = FEED_BADGE[it.type] || { label: it.type, cls: 'bg-accent text-muted-foreground' }
+                return (
+                  <div
+                    key={i}
+                    className={`flex items-center gap-3 py-2 ${it.symbol ? 'cursor-pointer hover:bg-accent/30' : ''}`}
+                    onClick={() => it.symbol && openStock(it.symbol, it.market || 'CN', it.name || '')}
+                  >
+                    <span className={`shrink-0 rounded px-1 text-[9px] ${badge.cls}`}>{badge.label}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px] font-medium">{it.name || it.symbol}</div>
+                      {it.why && <div className="truncate text-[11px] text-muted-foreground">{it.why}</div>}
+                    </div>
+                    <span className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px] ${pctChipCls(it.change_pct)}`}>
+                      {it.change_pct != null ? pct(it.change_pct) : '--'}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
         {/* 组合体检(并入首页) */}
-        <div className="card p-4">
+        <div className="card p-4 lg:col-span-5">
           <div className="mb-2 flex items-center gap-2">
             <ShieldAlert className="h-4 w-4 text-primary" />
             <h2 className="text-sm font-semibold">组合体检</h2>
@@ -364,33 +507,91 @@ export default function DashboardPage() {
               {loading ? '加载中…' : '暂无持仓,添加持仓后这里给风险与相对大盘表现'}
             </div>
           ) : (
-            <div className="space-y-2 text-[12px]">
-              <div className="flex items-center justify-between rounded bg-accent/15 px-2 py-1.5">
-                <span className="text-muted-foreground">近 60 日相对大盘</span>
-                <span className={`font-mono font-semibold ${moveColor(benchReady ? bench!.excess_return : null)}`}>
-                  {benchReady ? `超额 ${pct(bench!.excess_return)}` : '数据不足'}
-                </span>
+            <div className="space-y-3 text-[12px]">
+              {/* 图例行:色块 + 我的组合/基准收益 + 超额 chip */}
+              <div className="flex flex-wrap items-center justify-between gap-2 text-[11px]">
+                <div className="flex items-center gap-3">
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-[3px] w-3.5 rounded-full bg-primary" />
+                    <span className="text-muted-foreground">我的组合 {benchReady ? pct(bench!.portfolio_return) : ''}</span>
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-0 w-3.5 border-t-[1.5px] border-dashed border-muted-foreground/70" />
+                    <span className="text-muted-foreground">
+                      {bench?.benchmark_label || '沪深300'} {benchReady ? pct(bench!.benchmark_return) : ''}
+                    </span>
+                  </span>
+                </div>
+                {benchReady && (
+                  <span className={`rounded px-1.5 py-0.5 font-mono ${pctChipCls(bench!.excess_return)}`}>
+                    超额 {pct(bench!.excess_return)}
+                  </span>
+                )}
               </div>
+
+              {/* 净值 vs 基准双线图 */}
+              {benchReady && bench?.curve && bench.curve.length >= 2 ? (
+                <BenchChart curve={bench.curve} />
+              ) : (
+                <div className="flex h-[150px] items-center justify-center rounded-lg bg-accent/10 text-[11px] text-muted-foreground">
+                  基准对比计算中…
+                </div>
+              )}
+
               <div className="flex justify-between">
                 <span className="text-muted-foreground">持仓 {diag!.position_count} 只 · 最大单仓</span>
                 <span className={`font-mono ${diag!.max_weight >= 0.4 ? 'text-amber-600' : ''}`}>
                   {(diag!.max_weight * 100).toFixed(0)}%
                 </span>
               </div>
-              {Object.entries(diag!.by_market).map(([m, v]) => {
-                const w = diag!.total_market_value > 0 ? (v / diag!.total_market_value) * 100 : 0
-                return (
-                  <div key={m}>
-                    <div className="flex justify-between text-[11px]">
-                      <span>{m}</span>
-                      <span className="font-mono">{w.toFixed(0)}%</span>
-                    </div>
-                    <div className="h-1.5 rounded bg-accent/40">
-                      <div className="h-1.5 rounded bg-primary/60" style={{ width: `${Math.min(100, w)}%` }} />
-                    </div>
+
+              {/* 市场分布:stacked 单条 */}
+              {marketSegs.length > 0 && (
+                <div>
+                  <div className="flex h-2 overflow-hidden rounded-full bg-accent/30">
+                    {marketSegs.map((seg, i) => (
+                      <div
+                        key={seg.market}
+                        className={`h-full ${MARKET_BAR_CLS[seg.market] || 'bg-muted-foreground/50'}`}
+                        style={{ width: `${seg.pct}%`, marginRight: i < marketSegs.length - 1 ? 2 : 0 }}
+                      />
+                    ))}
                   </div>
-                )
-              })}
+                  <div className="mt-1 text-[10.5px] text-muted-foreground">
+                    {marketSegs.map((seg) => `${seg.market} ${seg.pct.toFixed(0)}%`).join(' · ')}
+                  </div>
+                </div>
+              )}
+
+              {/* 领涨/拖累:双向条 */}
+              {attribution.length > 1 &&
+                [
+                  { label: '领涨', item: attribution[0] },
+                  { label: '拖累', item: attribution[attribution.length - 1] },
+                ].map(({ label, item }) => {
+                  const w = Math.min(50, (Math.abs(item.contribution_pct) / attributionMaxAbs) * 50)
+                  const positive = item.contribution_pct >= 0
+                  return (
+                    <div key={label} className="flex items-center gap-2">
+                      <span className="w-8 shrink-0 text-[10px] text-muted-foreground">{label}</span>
+                      <div className="relative h-1.5 flex-1 rounded-full bg-accent/30">
+                        <div className="absolute inset-y-0 left-1/2 w-px bg-border" />
+                        <div
+                          className={`absolute inset-y-0 rounded-full ${positive ? 'bg-rose-500' : 'bg-emerald-500'}`}
+                          style={
+                            positive
+                              ? { left: '50%', width: `${w}%` }
+                              : { right: '50%', width: `${w}%` }
+                          }
+                        />
+                      </div>
+                      <span className="w-28 shrink-0 truncate text-right text-[11px]">
+                        {item.name} <span className={`font-mono ${moveColor(item.contribution_pct)}`}>{pct(item.contribution_pct)}</span>
+                      </span>
+                    </div>
+                  )
+                })}
+
               {diag!.alerts.length > 0 ? (
                 <div className="space-y-1 pt-1">
                   {diag!.alerts.map((a, i) => (
@@ -402,19 +603,6 @@ export default function DashboardPage() {
                 </div>
               ) : (
                 <div className="pt-1 text-[11px] text-emerald-500">✓ 集中度/分布未见明显风险</div>
-              )}
-              {attribution.length > 1 && (
-                <div className="flex justify-between pt-1 text-[11px] text-muted-foreground">
-                  <span>
-                    领涨 <span className={moveColor(attribution[0].contribution_pct)}>{attribution[0].name} {pct(attribution[0].contribution_pct)}</span>
-                  </span>
-                  <span>
-                    拖累{' '}
-                    <span className={moveColor(attribution[attribution.length - 1].contribution_pct)}>
-                      {attribution[attribution.length - 1].name} {pct(attribution[attribution.length - 1].contribution_pct)}
-                    </span>
-                  </span>
-                </div>
               )}
               <button
                 type="button"
@@ -434,7 +622,7 @@ export default function DashboardPage() {
         </div>
 
         {/* 机会精选 */}
-        <div className="card p-4">
+        <div className="card p-4 lg:col-span-5">
           <div className="mb-2 flex items-center justify-between">
             <h2 className="flex items-center gap-2 text-sm font-semibold">
               <Sparkles className="h-4 w-4 text-primary" />
@@ -452,52 +640,68 @@ export default function DashboardPage() {
             <div className="py-6 text-center text-[12px] text-muted-foreground">{loading ? '加载中…' : '暂无活跃机会信号'}</div>
           ) : (
             <div className="divide-y divide-border/40">
-              {opportunities.slice(0, 3).map((o) => (
-                <div
-                  key={`${o.stock_market}:${o.stock_symbol}`}
-                  className="flex cursor-pointer items-center gap-2 py-2 hover:bg-accent/30"
-                  onClick={() => openStock(o.stock_symbol, o.stock_market, o.stock_name || o.stock_symbol)}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      <span className="truncate text-[13px] font-medium">{o.stock_name || o.stock_symbol}</span>
-                      {o.action_label && <span className="rounded bg-primary/10 px-1 text-[9px] text-primary">{o.action_label}</span>}
+              {opportunities.slice(0, 3).map((o) => {
+                const score = Math.max(0, Math.min(100, o.rank_score ?? o.score ?? 0))
+                return (
+                  <div
+                    key={`${o.stock_market}:${o.stock_symbol}`}
+                    className="flex cursor-pointer items-center gap-2 py-2 hover:bg-accent/30"
+                    onClick={() => openStock(o.stock_symbol, o.stock_market, o.stock_name || o.stock_symbol)}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate text-[13px] font-medium">{o.stock_name || o.stock_symbol}</span>
+                        {o.action_label && <span className="rounded bg-primary/10 px-1 text-[9px] text-primary">{o.action_label}</span>}
+                      </div>
+                      {(o.signal || o.reason) && <div className="truncate text-[11px] text-muted-foreground">{o.signal || o.reason}</div>}
                     </div>
-                    {(o.signal || o.reason) && <div className="truncate text-[11px] text-muted-foreground">{o.signal || o.reason}</div>}
+                    <div className="shrink-0 text-right">
+                      <div className="font-mono text-[13px] text-foreground">{score.toFixed(0)}</div>
+                      <div className="text-[9px] text-muted-foreground">评分</div>
+                      <div className="mt-1 h-[3px] w-10 rounded bg-accent/40">
+                        <div className="h-[3px] rounded bg-primary/70" style={{ width: `${score}%` }} />
+                      </div>
+                    </div>
                   </div>
-                  <div className="shrink-0 text-right">
-                    <div className="font-mono text-[13px] text-foreground">{(o.rank_score ?? o.score ?? 0).toFixed(0)}</div>
-                    <div className="text-[9px] text-muted-foreground">评分</div>
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           )}
         </div>
-      </div>
 
-      {brief && (brief.title || brief.content) && (
-        <div className="card mt-3 p-4">
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="flex items-center gap-2 text-sm font-semibold">
-              <Newspaper className="h-4 w-4 text-primary" />
-              {brief.agent_label}
-              {brief.date && <span className="text-[11px] font-normal text-muted-foreground">{brief.date}</span>}
-            </h2>
-            {brief.content && (
-              <button type="button" className="text-[11px] text-muted-foreground" onClick={() => setBriefOpen((v) => !v)}>
-                {briefOpen ? '收起' : '展开'}
-              </button>
+        {/* 盘前/盘后简报 */}
+        {brief && (brief.title || brief.content) && (
+          <div className="card p-4 lg:col-span-7">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <h2 className="flex items-center gap-2 text-sm font-semibold">
+                <Newspaper className="h-4 w-4 text-primary" />
+                {brief.agent_label}
+              </h2>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                  AI{brief.date ? ` · ${brief.date}` : ''}
+                </span>
+                {brief.content && (
+                  <button
+                    type="button"
+                    className="text-[11px] text-muted-foreground hover:text-foreground"
+                    onClick={() => setBriefOpen((v) => !v)}
+                  >
+                    {briefOpen ? '收起' : '展开'}
+                  </button>
+                )}
+              </div>
+            </div>
+            {brief.title && <div className="text-[14.5px] font-semibold text-foreground">{brief.title}</div>}
+            {!briefOpen && briefSummary && <div className="mt-1 text-[12px] text-muted-foreground">{briefSummary}</div>}
+            {briefOpen && brief.content && (
+              <div className="prose prose-sm dark:prose-invert mt-1 max-w-none break-words text-[12px] [&_p]:my-1 [&_ul]:my-1">
+                <ReactMarkdown>{brief.content}</ReactMarkdown>
+              </div>
             )}
           </div>
-          {brief.title && <div className="text-[13px] font-medium">{brief.title}</div>}
-          {briefOpen && brief.content && (
-            <div className="prose prose-sm dark:prose-invert mt-1 max-w-none break-words text-[12px] [&_p]:my-1 [&_ul]:my-1">
-              <ReactMarkdown>{brief.content}</ReactMarkdown>
-            </div>
-          )}
-        </div>
-      )}
+        )}
+      </div>
 
       <DiscoveryPanel monitorStocks={scan} onOpenStock={openStock} />
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -148,9 +148,10 @@ export default function DashboardPage() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    // 快车道:DB/轻量查询,先让首屏(要紧事/指数/体检分布/组合速览)尽快出来
-    const [idx, sc, ov, dg, ht, td, ps, ms] = await Promise.allSettled([
-      dashboardApi.indices(),
+    // 指数 pills:独立加载不阻塞首屏(spark 冷启动可能 ~1s,数据到了自然浮现)
+    dashboardApi.indices().then(setIndices).catch(() => {})
+    // 快车道:DB/轻量查询,先让首屏(要紧事/体检分布/组合速览)尽快出来
+    const [sc, ov, dg, ht, td, ps, ms] = await Promise.allSettled([
       dashboardApi.intradayScan(),
       dashboardApi.overview({ market: 'ALL', action_limit: 6, risk_limit: 6 }),
       portfolioApi.diagnostics(),
@@ -159,7 +160,6 @@ export default function DashboardPage() {
       dashboardApi.portfolioSummary(),
       dashboardApi.marketStatus(),
     ])
-    if (idx.status === 'fulfilled') setIndices(idx.value)
     if (sc.status === 'fulfilled') setScan(sc.value.stocks || [])
     if (ov.status === 'fulfilled') setOverview(ov.value)
     if (dg.status === 'fulfilled') setDiag(dg.value)

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -106,6 +106,7 @@ export default function DashboardPage() {
   const [overview, setOverview] = useState<DashboardOverviewResponse | null>(null)
   const [diag, setDiag] = useState<PortfolioDiagnostics | null>(null)
   const [bench, setBench] = useState<PortfolioBenchmark | null>(null)
+  const [benchState, setBenchState] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading')
   const [oppFallback, setOppFallback] = useState<StrategySignalItem[]>([])
   const [alertHits, setAlertHits] = useState<AlertHitToday[]>([])
   const [todos, setTodos] = useState<PortfolioTodo[]>([])
@@ -130,6 +131,20 @@ export default function DashboardPage() {
     name: '',
     hasPosition: false,
   })
+
+  // 慢车道:基准/归因(拉全持仓 K 线,分钟级);独立可重试,失败/为空各有明确状态
+  const loadBench = useCallback(() => {
+    setBenchState('loading')
+    Promise.allSettled([portfolioApi.benchmark({ days: 60 }), portfolioApi.attribution(60)]).then(([bn, at]) => {
+      if (bn.status === 'fulfilled') {
+        setBench(bn.value)
+        setBenchState(!bn.value?.empty && (bn.value?.curve?.length ?? 0) >= 2 ? 'ready' : 'empty')
+      } else {
+        setBenchState('error')
+      }
+      if (at.status === 'fulfilled') setAttribution(at.value.items || [])
+    })
+  }, [])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -163,11 +178,8 @@ export default function DashboardPage() {
         .catch(() => {})
     }
 
-    // 慢车道:基准/归因需拉全持仓 K 线(40s 级),独立加载,就绪后回填超额/归因
-    Promise.allSettled([portfolioApi.benchmark({ days: 60 }), portfolioApi.attribution(60)]).then(([bn, at]) => {
-      if (bn.status === 'fulfilled') setBench(bn.value)
-      if (at.status === 'fulfilled') setAttribution(at.value.items || [])
-    })
+    // 慢车道:基准/归因需拉全持仓 K 线(分钟级),独立加载,就绪后回填超额/归因
+    loadBench()
 
     // 盘前/盘后简报:独立加载,取较新一条
     Promise.allSettled([dashboardApi.brief('premarket'), dashboardApi.brief('eod')]).then((res) => {
@@ -177,7 +189,7 @@ export default function DashboardPage() {
       briefs.sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''))
       setBrief(briefs[0] || null)
     })
-  }, [])
+  }, [loadBench])
 
   useEffect(() => {
     load()
@@ -529,12 +541,25 @@ export default function DashboardPage() {
                 )}
               </div>
 
-              {/* 净值 vs 基准双线图 */}
-              {benchReady && bench?.curve && bench.curve.length >= 2 ? (
+              {/* 净值 vs 基准双线图:loading/ready/empty/error 四态,不再永远"计算中" */}
+              {benchState === 'ready' && bench?.curve && bench.curve.length >= 2 ? (
                 <BenchChart curve={bench.curve} />
               ) : (
-                <div className="flex h-[150px] items-center justify-center rounded-lg bg-accent/10 text-[11px] text-muted-foreground">
-                  基准对比计算中…
+                <div className="flex h-[150px] flex-col items-center justify-center gap-2 rounded-lg bg-accent/10 text-[11px] text-muted-foreground">
+                  {benchState === 'loading' && <span>基准对比计算中…(需拉全部持仓 K 线,约 1 分钟)</span>}
+                  {benchState === 'empty' && <span>{bench?.reason || '数据不足,暂无法计算基准对比'}</span>}
+                  {benchState === 'error' && (
+                    <>
+                      <span>基准对比加载失败(超时或网络异常)</span>
+                      <button
+                        type="button"
+                        onClick={loadBench}
+                        className="rounded border border-border/60 px-2.5 py-1 text-[11px] text-primary hover:bg-accent/30"
+                      >
+                        重试
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
 

--- a/packages/marketdata/src/marketdata/client.py
+++ b/packages/marketdata/src/marketdata/client.py
@@ -41,6 +41,19 @@ INDEX_SECID: dict[str, str] = {
     "HSI": "100.HSI",       # 恒生指数
 }
 
+# 指数的原始腾讯符号(index_klines 的腾讯兜底路径;美股指数东财无 secid,只能走这里,
+# 腾讯对美股指数只返最近几根,短但可用)。
+INDEX_TENCENT: dict[str, str] = {
+    "000001": "sh000001",   # 上证指数
+    "399001": "sz399001",   # 深证成指
+    "399006": "sz399006",   # 创业板指
+    "000300": "sh000300",   # 沪深300
+    "HSI": "hkHSI",         # 恒生指数
+    "IXIC": "usIXIC",       # 纳斯达克
+    "DJI": "usDJI",         # 道琼斯
+    "INX": "usINX",         # 标普500
+}
+
 
 class MarketData:
     def __init__(self, config: ConfigProvider, metrics: MetricsSink | None = None):
@@ -161,12 +174,23 @@ class MarketData:
         return fetch_raw(list(tencent_symbols)) if tencent_symbols else []
 
     def index_klines(self, code: str, *, market: str, days: int = 120) -> list:
-        """指数日K:INDEX_SECID 显式映射走东财;未映射(如美股指数)→ [](fail-soft)。返回 list[Bar]。"""
-        secid = INDEX_SECID.get(str(code).strip()) or INDEX_SECID.get(str(code).strip().upper())
-        if not secid:
-            return []
-        from marketdata.vendors.kline import fetch_eastmoney_kline
-        return fetch_eastmoney_kline(secid, days)
+        """指数日K:东财 secid 主源;失败/未映射(如美股指数)走腾讯原始符号兜底;都无 → []。
+
+        腾讯兜底修两类缺口:①东财 push2his 被代理/风控掐时 CN/HK 指数仍有数;
+        ②美股指数(IXIC/DJI/INX)东财无 secid,腾讯可出(仅最近几根,短但可用)。返回 list[Bar]。
+        """
+        c = str(code).strip()
+        secid = INDEX_SECID.get(c) or INDEX_SECID.get(c.upper())
+        if secid:
+            from marketdata.vendors.kline import fetch_eastmoney_kline
+            bars = fetch_eastmoney_kline(secid, days)
+            if bars:
+                return bars
+        tsym = INDEX_TENCENT.get(c) or INDEX_TENCENT.get(c.upper())
+        if tsym:
+            from marketdata.vendors.kline import fetch_tencent_kline_raw
+            return fetch_tencent_kline_raw(tsym, days)
+        return []
 
     def capital_flow(self, symbol: str, *, market: str = "CN") -> CapitalFlow | None:
         """单只股票资金流向。不在包内缓存(cache_ttl_sec=0);宿主自行缓存。"""

--- a/packages/marketdata/src/marketdata/vendors/kline.py
+++ b/packages/marketdata/src/marketdata/vendors/kline.py
@@ -70,6 +70,30 @@ def fetch_tencent_kline_raw(tsym: str, days: int) -> list[Bar]:
     return out
 
 
+# 腾讯美股日K必须带交易所后缀(usTSLA.OQ=纳斯达克 / usBABA.N=纽交所);裸 us{CODE}
+# 只回"首日+最新"两根退化数据,错后缀只回 1 根。后缀无法从代码推断 → 依次试
+# .OQ/.N/裸,根数达标即命中并进程内记忆(下次直达,不再多请求)。
+_US_SUFFIX_CACHE: dict[str, str] = {}
+
+
+def _fetch_tencent_us_kline(code: str, days: int) -> list[Bar]:
+    want = min(max(int(days or 1), 1), _TENCENT_MAX_COUNT)
+    ok_threshold = min(want, 5)  # 正常历史远多于 5 根;退化响应只有 1-2 根
+    cached = _US_SUFFIX_CACHE.get(code)
+    suffixes = ([cached] if cached is not None else []) + [
+        s for s in (".OQ", ".N", "") if s != cached
+    ]
+    best: list[Bar] = []
+    for suf in suffixes:
+        bars = fetch_tencent_kline_raw(f"us{code}{suf}", want)
+        if len(bars) >= ok_threshold:
+            _US_SUFFIX_CACHE[code] = suf
+            return bars
+        if len(bars) > len(best):
+            best = bars
+    return best
+
+
 class TencentKlineVendor(KlineVendor):
     name = "tencent"
     supports_markets = {"CN", "HK", "US"}
@@ -80,6 +104,8 @@ class TencentKlineVendor(KlineVendor):
         if not symbols:
             return []
         sym = symbols[0]
+        if sym.market == Market.US:
+            return _fetch_tencent_us_kline(sym.code, _days(config))
         return fetch_tencent_kline_raw(sym.to_tencent(), _days(config))
 
 

--- a/packages/marketdata/src/marketdata/vendors/kline.py
+++ b/packages/marketdata/src/marketdata/vendors/kline.py
@@ -12,7 +12,7 @@ from marketdata.vendors.base import KlineVendor
 
 logger = logging.getLogger(__name__)
 
-_TENCENT_URL = "http://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
+_TENCENT_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
 _EASTMONEY_URL = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
 _STOOQ_URL = "https://stooq.com/q/d/l/"
 _YAHOO_CHART_URL = "https://query2.finance.yahoo.com/v8/finance/chart/{sym}"
@@ -25,51 +25,62 @@ def _days(config: dict, default: int = 60) -> int:
         return default
 
 
+# 腾讯 fqkline 对 count 有上限:实测 ≤800 正常返(800→801根),1000-2000 退化到 ~641,
+# ≥3000 直接返空(0根)。上层 want 常放大到 3000(为长历史/回测),若原样透传腾讯会返 0
+# → 每个标的都白白落到东财补全 → 东财一挂就没数据。故把请求 count 截到 800(取回最多)。
+_TENCENT_MAX_COUNT = 800
+
+
+def fetch_tencent_kline_raw(tsym: str, days: int) -> list[Bar]:
+    """按**原始腾讯符号**取日K(不经 Symbol 转换)。
+
+    供指数等显式符号场景复用(sh000001/hkHSI/usDJI…;指数与个股的符号规则不同,
+    必须显式传入)。个股路径请走 TencentKlineVendor。
+    """
+    days = min(max(int(days or 1), 1), _TENCENT_MAX_COUNT)
+    text = market_get(
+        _TENCENT_URL, host_key="web.ifzq.gtimg.cn", min_interval_s=0.15,
+        params={"param": f"{tsym},day,,,{days},qfq", "_var": "kline_dayqfq"},
+        timeout=10, retries=2, parse="text", log_label="腾讯K线", symbol=tsym,
+    )
+    if not text or "=" not in text:
+        return []
+    js = text.split("=", 1)[1].strip().rstrip(";")
+    try:
+        data = json.loads(js)
+    except Exception:
+        return []
+    raw = data.get("data", {}) if isinstance(data, dict) else {}
+    day = []
+    if isinstance(raw, dict):
+        sd = raw.get(tsym, {})
+        if isinstance(sd, dict):
+            day = sd.get("day") or sd.get("qfqday") or []
+    elif isinstance(raw, list):
+        day = raw
+    out: list[Bar] = []
+    for it in day or []:
+        if len(it) >= 5:
+            try:
+                out.append(Bar(date=it[0], open=float(it[1]), close=float(it[2]),
+                               high=float(it[3]), low=float(it[4]),
+                               volume=float(it[5]) if len(it) > 5 else 0.0))
+            except Exception:
+                continue
+    return out
+
+
 class TencentKlineVendor(KlineVendor):
     name = "tencent"
     supports_markets = {"CN", "HK", "US"}
 
-    # 腾讯 fqkline 对 count 有上限:实测 ≤800 正常返(800→801根),1000-2000 退化到 ~641,
-    # ≥3000 直接返空(0根)。上层 want 常放大到 3000(为长历史/回测),若原样透传腾讯会返 0
-    # → 每个标的都白白落到东财补全 → 东财一挂就没数据。故这里把请求 count 截到 800(取回最多)。
-    _MAX_COUNT = 800
+    _MAX_COUNT = _TENCENT_MAX_COUNT  # 兼容旧引用(测试/外部按类属性取)
 
     def fetch(self, symbols: list[Symbol], config: dict) -> list[Bar]:
         if not symbols:
             return []
         sym = symbols[0]
-        days = min(_days(config), self._MAX_COUNT)
-        tsym = sym.to_tencent()
-        text = market_get(
-            _TENCENT_URL, host_key="web.ifzq.gtimg.cn", min_interval_s=0.15,
-            params={"param": f"{tsym},day,,,{days},qfq", "_var": "kline_dayqfq"},
-            timeout=10, retries=2, parse="text", log_label="腾讯K线", symbol=sym.code,
-        )
-        if not text or "=" not in text:
-            return []
-        js = text.split("=", 1)[1].strip().rstrip(";")
-        try:
-            data = json.loads(js)
-        except Exception:
-            return []
-        raw = data.get("data", {}) if isinstance(data, dict) else {}
-        day = []
-        if isinstance(raw, dict):
-            sd = raw.get(tsym, {})
-            if isinstance(sd, dict):
-                day = sd.get("day") or sd.get("qfqday") or []
-        elif isinstance(raw, list):
-            day = raw
-        out: list[Bar] = []
-        for it in day or []:
-            if len(it) >= 5:
-                try:
-                    out.append(Bar(date=it[0], open=float(it[1]), close=float(it[2]),
-                                   high=float(it[3]), low=float(it[4]),
-                                   volume=float(it[5]) if len(it) > 5 else 0.0))
-                except Exception:
-                    continue
-        return out
+        return fetch_tencent_kline_raw(sym.to_tencent(), _days(config))
 
 
 class StooqKlineVendor(KlineVendor):

--- a/packages/marketdata/tests/test_index_methods.py
+++ b/packages/marketdata/tests/test_index_methods.py
@@ -39,6 +39,53 @@ def test_index_klines(monkeypatch):
     assert out and out[0].close == 3200.0 and out[0].high == 3210.0
 
 
-def test_index_klines_unmapped_returns_empty():
-    """美股指数(如 IXIC)未在 INDEX_SECID 映射中 → 空列表,fail-soft。"""
-    assert _md().index_klines("IXIC", market="US", days=120) == []
+def test_index_klines_unmapped_returns_empty(monkeypatch):
+    """两套映射(东财 secid / 腾讯符号)都没有的指数 → 空列表,fail-soft,且不发请求。"""
+    calls = {"n": 0}
+    def _boom(*a, **k):
+        calls["n"] += 1
+        return None
+    monkeypatch.setattr(kv, "market_get", _boom)
+    assert _md().index_klines("FTSE", market="EU", days=120) == []
+    assert calls["n"] == 0
+
+
+def _tencent_kline_text(tsym: str) -> str:
+    return ('kline_dayqfq={"data":{"' + tsym + '":{"day":['
+            '["2026-07-24","17800.0","17862.4","17900.0","17750.0","1000"],'
+            '["2026-07-25","17862.4","17910.2","17950.0","17800.0","1100"]]}}}')
+
+
+def test_index_klines_us_via_tencent_fallback(monkeypatch):
+    """美股指数(IXIC)东财无 secid → 走腾讯原始符号兜底出数(修旧缺口)。"""
+    def _fake(url, **k):
+        assert "usIXIC" in k["params"]["param"]
+        return _tencent_kline_text("usIXIC")
+    monkeypatch.setattr(kv, "market_get", _fake)
+    out = _md().index_klines("IXIC", market="US", days=120)
+    assert len(out) == 2 and out[-1].close == 17910.2
+
+
+def test_index_klines_eastmoney_empty_falls_back_to_tencent(monkeypatch):
+    """CN 指数东财空(如被代理/风控掐)→ 腾讯兜底出数。"""
+    def _fake(url, **k):
+        if "push2his" in url:
+            return {"data": {"klines": []}}
+        return _tencent_kline_text("sh000001")
+    monkeypatch.setattr(kv, "market_get", _fake)
+    out = _md().index_klines("000001", market="CN", days=120)
+    assert len(out) == 2 and out[0].date == "2026-07-24"
+
+
+def test_index_klines_eastmoney_ok_skips_tencent(monkeypatch):
+    """东财主源有数 → 不再调腾讯兜底(主备语义,不是聚合)。"""
+    calls = {"tencent": 0}
+    def _fake(url, **k):
+        if "push2his" in url:
+            return {"data": {"klines": ["2026-07-01,3180,3200,3210,3170,100000"]}}
+        calls["tencent"] += 1
+        return _tencent_kline_text("sh000001")
+    monkeypatch.setattr(kv, "market_get", _fake)
+    out = _md().index_klines("000001", market="CN", days=120)
+    assert out and out[0].close == 3200.0
+    assert calls["tencent"] == 0

--- a/packages/marketdata/tests/test_kline_vendors.py
+++ b/packages/marketdata/tests/test_kline_vendors.py
@@ -23,3 +23,36 @@ def test_stooq_kline_parses(monkeypatch):
     monkeypatch.setattr(kv, "market_get", lambda *a, **k: csv)
     out = kv.StooqKlineVendor().fetch([Symbol.parse("AAPL")], {})
     assert len(out) == 2 and out[0].close == 3.0 and out[1].close == 5.0
+
+
+def test_tencent_us_kline_resolves_exchange_suffix(monkeypatch):
+    """腾讯美股日K:裸符号只回退化数据(2根)→ 自动试 .OQ/.N 后缀并记忆命中,二次直达。"""
+    import json as _j
+
+    kv._US_SUFFIX_CACHE.clear()
+    calls = []
+
+    def fake(url, **k):
+        param = k["params"]["param"]
+        calls.append(param)
+        tsym = param.split(",")[0]
+        if tsym == "usBABA.N":  # 纽交所后缀才是对的
+            days = [[f"2026-07-{i:02d}", "1", "2", "3", "0.5", "10"] for i in range(1, 11)]
+        elif tsym in ("usBABA.OQ", "usBABA"):  # 错后缀/裸符号 → 退化 2 根
+            days = [["2011-06-02", "1", "2", "3", "0.5", "10"],
+                    ["2026-07-31", "1", "2", "3", "0.5", "10"]]
+        else:
+            days = []
+        return "k=" + _j.dumps({"data": {tsym: {"day": days}}})
+
+    monkeypatch.setattr(kv, "market_get", fake)
+    v = kv.TencentKlineVendor()
+    out = v.fetch([Symbol.parse("BABA", market="US")], {"days": 30})
+    assert len(out) == 10
+    assert calls[0].startswith("usBABA.OQ")  # 先试纳斯达克
+    assert kv._US_SUFFIX_CACHE.get("BABA") == ".N"
+
+    calls.clear()
+    out2 = v.fetch([Symbol.parse("BABA", market="US")], {"days": 30})
+    assert len(out2) == 10 and len(calls) == 1  # 记忆后缀后一次请求直达
+    kv._US_SUFFIX_CACHE.clear()

--- a/src/core/portfolio_benchmark.py
+++ b/src/core/portfolio_benchmark.py
@@ -17,7 +17,7 @@ from src.models.market import MarketCode
 logger = logging.getLogger(__name__)
 
 # 腾讯日K接口(与 kline_collector.TENCENT_KLINE_URL 同源,本地化以解除对其内部符号的依赖)
-_TENCENT_KLINE_URL = "http://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
+_TENCENT_KLINE_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
 
 
 def _parse_tencent_kline(text: str, tencent_sym: str) -> list[KlineData]:

--- a/src/core/portfolio_benchmark.py
+++ b/src/core/portfolio_benchmark.py
@@ -192,14 +192,23 @@ def build_portfolio_benchmark(
     if not holding_series:
         return None
 
-    # 所有持仓都有数据的起点,避免早期持仓缺数导致 NAV 失真
-    start_date = max(hs[2] for hs in holding_series)
+    # 所有持仓都有数据的起点,避免早期持仓缺数导致 NAV 失真;
+    # 但覆盖极差的单只持仓(坏源/新股,只有最近 1-2 根)不许一票否决整个窗口:
+    # 保底窗口 = max(10, 基准天数一半),覆盖不到保底窗口起点的持仓剔除出 NAV(记入 excluded)。
+    min_window = max(10, len(bench_dates) // 2)
+    floor_date = bench_dates[-min_window] if len(bench_dates) >= min_window else bench_dates[0]
+    kept = [hs for hs in holding_series if hs[2] <= floor_date]
+    excluded = [hs[0]["symbol"] for hs in holding_series if hs[2] > floor_date]
+    if not kept:
+        return None
+
+    start_date = max(hs[2] for hs in kept)
     dates = [d for d in bench_dates if d >= start_date]
     if len(dates) < 2:
         return None
 
     nav = [0.0] * len(dates)
-    for h, bars, _ in holding_series:
+    for h, bars, _ in kept:
         closes = _ffill_closes(bars, dates)
         qfx = float(h.get("quantity", 0)) * float(h.get("fx", 1.0))
         for k in range(len(dates)):
@@ -211,6 +220,9 @@ def build_portfolio_benchmark(
     if metrics:
         metrics["benchmark_code"] = benchmark_code
         metrics["benchmark_label"] = benchmark_label(benchmark_code)
+        if excluded:
+            # 覆盖不足被剔除的持仓(如坏源/新股),供上层展示"基于 N-x 只计算"
+            metrics["excluded"] = excluded
     return metrics
 
 

--- a/src/web/api/market.py
+++ b/src/web/api/market.py
@@ -1,6 +1,10 @@
 """市场指数 API - 公共数据，无需认证"""
 import logging
+import time
 from fastapi import APIRouter
+
+from src.collectors.kline_collector import get_index_klines
+from src.models.market import MarketCode
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -26,10 +30,39 @@ MARKET_INDICES = [
     {"symbol": "DJI", "name": "道琼斯", "market": "US", "tencent_symbol": "usDJI", "response_symbol": ".DJI"},
 ]
 
+# 指数响应内存缓存:附加 spark 每次都要多拉 5 组指数K线,60s 缓存避免首页每次加载都联网。
+_INDICES_CACHE: dict[str, tuple[float, list[dict]]] = {}
+_INDICES_CACHE_TTL_S = 60
+
+
+def clear_indices_cache() -> None:
+    """清空指数响应缓存(测试隔离用)。"""
+    _INDICES_CACHE.clear()
+
+
+def _spark_for(idx: dict) -> list[float]:
+    """近 20 日收盘价,供首页指数走势 sparkline 用。
+
+    fail-soft:市场码非法/取数异常/无 INDEX_SECID 映射(如美股指数)一律吞掉异常,
+    返回空列表,绝不影响 quote 主体。
+    """
+    try:
+        market_code = MarketCode(idx["market"])
+        klines = get_index_klines(idx["symbol"], market_code, days=20)
+        return [k.close for k in klines] if klines else []
+    except Exception as e:
+        logger.debug(f"指数 spark 获取失败 {idx['symbol']}: {e}")
+        return []
+
 
 @router.get("/indices")
 async def get_market_indices():
     """获取主要市场指数（公共数据，无需认证）"""
+    now = time.time()
+    cached = _INDICES_CACHE.get("indices")
+    if cached and now - cached[0] < _INDICES_CACHE_TTL_S:
+        return cached[1]
+
     tencent_symbols = [idx["tencent_symbol"] for idx in MARKET_INDICES]
 
     try:
@@ -47,6 +80,7 @@ async def get_market_indices():
     for idx in MARKET_INDICES:
         # 使用 response_symbol 匹配
         quote = quote_map.get(idx["response_symbol"])
+        spark = _spark_for(idx)
 
         if quote:
             result.append({
@@ -57,6 +91,7 @@ async def get_market_indices():
                 "change_pct": quote["change_pct"],
                 "change_amount": quote["change_amount"],
                 "prev_close": quote["prev_close"],
+                "spark": spark,
             })
         else:
             # 即使没有行情也返回基本信息
@@ -68,6 +103,8 @@ async def get_market_indices():
                 "change_pct": None,
                 "change_amount": None,
                 "prev_close": None,
+                "spark": spark,
             })
 
+    _INDICES_CACHE["indices"] = (now, result)
     return result

--- a/src/web/api/market.py
+++ b/src/web/api/market.py
@@ -1,4 +1,5 @@
 """市场指数 API - 公共数据，无需认证"""
+import asyncio
 import logging
 import time
 from fastapi import APIRouter
@@ -30,29 +31,41 @@ MARKET_INDICES = [
     {"symbol": "DJI", "name": "道琼斯", "market": "US", "tencent_symbol": "usDJI", "response_symbol": ".DJI"},
 ]
 
-# 指数响应内存缓存:附加 spark 每次都要多拉 5 组指数K线,60s 缓存避免首页每次加载都联网。
+# 指数响应内存缓存:60s(行情价格要新鲜)。
 _INDICES_CACHE: dict[str, tuple[float, list[dict]]] = {}
 _INDICES_CACHE_TTL_S = 60
 
+# spark(近20日收盘)独立缓存:日线一天才变,30 分钟足够新鲜。
+# 没有它,响应缓存每 60s 过期就要重付一轮 6×指数K线(部分环境东财先失败再腾讯兜底,
+# 串行约 4s)——这曾是首页快车道最大的延迟来源。空结果也缓存(坏源别反复重拉)。
+_SPARK_CACHE: dict[str, tuple[float, list[float]]] = {}
+_SPARK_TTL_S = 1800
+
 
 def clear_indices_cache() -> None:
-    """清空指数响应缓存(测试隔离用)。"""
+    """清空指数响应/spark 缓存(测试隔离用)。"""
     _INDICES_CACHE.clear()
+    _SPARK_CACHE.clear()
 
 
 def _spark_for(idx: dict) -> list[float]:
-    """近 20 日收盘价,供首页指数走势 sparkline 用。
+    """近 20 日收盘价,供首页指数走势 sparkline 用(带 30min 独立缓存)。
 
-    fail-soft:市场码非法/取数异常/无 INDEX_SECID 映射(如美股指数)一律吞掉异常,
-    返回空列表,绝不影响 quote 主体。
+    fail-soft:市场码非法/取数异常/无映射一律吞掉,返回空列表,绝不影响 quote 主体。
     """
+    now = time.time()
+    hit = _SPARK_CACHE.get(idx["symbol"])
+    if hit and now - hit[0] < _SPARK_TTL_S:
+        return hit[1]
     try:
         market_code = MarketCode(idx["market"])
         klines = get_index_klines(idx["symbol"], market_code, days=20)
-        return [k.close for k in klines] if klines else []
+        spark = [k.close for k in klines] if klines else []
     except Exception as e:
         logger.debug(f"指数 spark 获取失败 {idx['symbol']}: {e}")
-        return []
+        spark = []
+    _SPARK_CACHE[idx["symbol"]] = (now, spark)
+    return spark
 
 
 @router.get("/indices")
@@ -76,11 +89,21 @@ async def get_market_indices():
     for q in quotes:
         quote_map[q["symbol"]] = q
 
+    # spark 并行取(缓存未过期时零成本;冷启动=最慢单个≈1s,而非 6 个串行累加)
+    sparks = await asyncio.gather(
+        *[asyncio.to_thread(_spark_for, idx) for idx in MARKET_INDICES],
+        return_exceptions=True,
+    )
+    spark_map = {
+        idx["symbol"]: (sp if isinstance(sp, list) else [])
+        for idx, sp in zip(MARKET_INDICES, sparks)
+    }
+
     result = []
     for idx in MARKET_INDICES:
         # 使用 response_symbol 匹配
         quote = quote_map.get(idx["response_symbol"])
-        spark = _spark_for(idx)
+        spark = spark_map.get(idx["symbol"], [])
 
         if quote:
             result.append({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,10 +62,12 @@ def _clear_market_caches():
         capital_flow_collector,
         kline_collector,
     )
+    from src.web.api import market as market_api
 
     def _clear():
         kline_collector.clear_kline_cache()
         capital_flow_collector._FLOW_CACHE.clear()
+        market_api.clear_indices_cache()
 
     _clear()
     yield

--- a/tests/test_index_routing.py
+++ b/tests/test_index_routing.py
@@ -46,6 +46,8 @@ def test_get_market_indices_uses_marketdata(monkeypatch):
             ]
 
     monkeypatch.setattr(mkt, "get_market_data", lambda: _MD())
+    # spark 取数不是本用例关注点,桩掉避免真实联网(见 test_market_indices_spark.py 专测 spark)。
+    monkeypatch.setattr(mkt, "get_index_klines", lambda *a, **k: [])
 
     out = asyncio.run(mkt.get_market_indices())
 

--- a/tests/test_market_indices_spark.py
+++ b/tests/test_market_indices_spark.py
@@ -1,0 +1,118 @@
+"""首页指数 spark(近20日收盘) 注入 + 60s 缓存 + fail-soft 测试"""
+import asyncio
+
+import src.web.api.market as mkt
+
+
+class _K:
+    """极简 K 线桩,只需 .close 供 spark 取值。"""
+
+    def __init__(self, close: float):
+        self.close = close
+
+
+def test_spark_injected_for_each_index(monkeypatch):
+    """每个指数都应附上 spark(近20日收盘价列表),与 get_index_klines 返回的 close 序列一致。"""
+    mkt.clear_indices_cache()
+
+    captured_days: dict[str, int] = {}
+
+    def _fake_quotes(tencent_symbols):
+        return [
+            {
+                "symbol": "000001",
+                "name": "上证指数",
+                "current_price": 3200.0,
+                "change_pct": 0.63,
+                "change_amount": 20.0,
+                "prev_close": 3180.0,
+            },
+        ]
+
+    class _MD:
+        def index_quotes(self, tencent_symbols):
+            return _fake_quotes(tencent_symbols)
+
+    def _fake_get_index_klines(code, market, days=120):
+        captured_days[code] = days
+        return [_K(100 + i) for i in range(20)]
+
+    monkeypatch.setattr(mkt, "get_market_data", lambda: _MD())
+    monkeypatch.setattr(mkt, "get_index_klines", _fake_get_index_klines)
+
+    out = asyncio.run(mkt.get_market_indices())
+
+    assert len(out) == len(mkt.MARKET_INDICES)
+    for item in out:
+        assert item["spark"] == [100 + i for i in range(20)]
+    # 近20日收盘:days=20 原样透传
+    assert all(d == 20 for d in captured_days.values())
+
+
+def test_spark_failsoft_on_error_or_unmapped(monkeypatch):
+    """单指数取 spark 异常(如美股指数无 INDEX_SECID 映射)→ spark=[],不影响 quote 主体也不抛异常。"""
+    mkt.clear_indices_cache()
+
+    class _MD:
+        def index_quotes(self, tencent_symbols):
+            return [
+                {
+                    "symbol": "000001",
+                    "name": "上证指数",
+                    "current_price": 3200.0,
+                    "change_pct": 0.63,
+                    "change_amount": 20.0,
+                    "prev_close": 3180.0,
+                },
+            ]
+
+    def _boom(code, market, days=120):
+        raise RuntimeError(f"boom for {code}")
+
+    monkeypatch.setattr(mkt, "get_market_data", lambda: _MD())
+    monkeypatch.setattr(mkt, "get_index_klines", _boom)
+
+    out = asyncio.run(mkt.get_market_indices())
+
+    # quote 主体不受影响:上证指数仍返回正确行情
+    sh = next(i for i in out if i["symbol"] == "000001")
+    assert sh["current_price"] == 3200.0
+    assert sh["spark"] == []
+    # 未映射/取数失败的指数(如美股)同样 spark=[] 且仍在结果里
+    assert all(i["spark"] == [] for i in out)
+    assert len(out) == len(mkt.MARKET_INDICES)
+
+
+def test_indices_response_cached_60s(monkeypatch):
+    """整个 indices 响应加 60s 进程内缓存:短时间内重复调用不应重复拉取 quote/K线。"""
+    mkt.clear_indices_cache()
+
+    call_count = {"quotes": 0, "klines": 0}
+
+    class _MD:
+        def index_quotes(self, tencent_symbols):
+            call_count["quotes"] += 1
+            return [
+                {
+                    "symbol": "000001",
+                    "name": "上证指数",
+                    "current_price": 3200.0,
+                    "change_pct": 0.63,
+                    "change_amount": 20.0,
+                    "prev_close": 3180.0,
+                },
+            ]
+
+    def _fake_get_index_klines(code, market, days=120):
+        call_count["klines"] += 1
+        return [_K(100 + i) for i in range(20)]
+
+    monkeypatch.setattr(mkt, "get_market_data", lambda: _MD())
+    monkeypatch.setattr(mkt, "get_index_klines", _fake_get_index_klines)
+
+    out1 = asyncio.run(mkt.get_market_indices())
+    out2 = asyncio.run(mkt.get_market_indices())
+
+    assert out1 == out2
+    assert call_count["quotes"] == 1
+    assert call_count["klines"] == len(mkt.MARKET_INDICES)  # 只在第一次调用时逐指数拉取一次

--- a/tests/test_portfolio_benchmark.py
+++ b/tests/test_portfolio_benchmark.py
@@ -89,3 +89,28 @@ def test_build_portfolio_benchmark_with_mocked_fetch(monkeypatch):
     assert res["benchmark_return"] == 21.0
     assert res["excess_return"] == -21.0
     assert res["relative_drawdown"] < 0
+
+
+def test_build_benchmark_excludes_poor_coverage_holding(monkeypatch):
+    """单只覆盖极差的持仓(坏源只回最近1根)被剔除并记入 excluded,不再一票否决基准对比。"""
+    dates = [f"2026-01-{d:02d}" for d in range(2, 14)]  # 12 个交易日
+    monkeypatch.setattr(
+        pb, "_fetch_benchmark_series",
+        lambda code, days: (dates, [100.0 + i for i in range(len(dates))]),
+    )
+
+    def fake_fetch(symbol, market):
+        if symbol == "BABA":
+            return _bars([(dates[-1], 200.0)])  # 只有最近 1 根 → 覆盖不足
+        return _bars([(d, 10.0 + i * 0.1) for i, d in enumerate(dates)])
+
+    res = pb.build_portfolio_benchmark(
+        [
+            {"symbol": "600519", "market": "CN", "quantity": 100, "fx": 1.0},
+            {"symbol": "BABA", "market": "US", "quantity": 10, "fx": 7.0},
+        ],
+        days=60,
+        kline_fetch=fake_fetch,
+    )
+    assert res is not None and len(res.get("curve") or []) >= 2
+    assert res.get("excluded") == ["BABA"]


### PR DESCRIPTION
## 概述
按已过审的设计稿(高保真 mockup)落地首页视觉改版。**信息架构与数据流零改动**(要紧事/体检/机会/简报/发现 + 快慢加载车道全保留),只补图形层。

## 改动
- **组合速览条**:今日盈亏 hero 大数字 + 累计浮盈 + 60日超额 + 仓位% + 净值 mini 曲线 + 持仓页入口(无持仓优雅降级)
- **指数走势 pills**:5 张带近 20 日走势线的指数卡(涨跌色渲染)
- **体检卡**:组合 vs 沪深300 双线面积图(用了一直存在却没画的 `bench.curve`)+ 市场分布彩条 + 领涨/拖累归因条
- **要紧事/机会/简报**:涨跌着色 chip、评分条、简报标题层级 + 摘要行
- 新组件 `Sparkline` / `BenchChart`(零第三方图表库,亮暗双主题,ResizeObserver 自适应)
- **唯一后端改动**:`/api/market/indices` 附 `spark`(近20日收盘,60s 缓存,fail-soft;美股指数无 secid 映射返回空、前端优雅降级)

## 验证
- 后端 461 passed;前端 `pnpm build` 零错
- 组件沙盒截图核对亮/暗主题、宽窄自适应、空数据边界
- grep 自查:策展/待办/分享卡/弹窗/Onboarding 逻辑全部原样