### PR TITLE
fix(scheduler): 非交易日不再推送模拟盘通知 + 引入交易日历(含法定节假日)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 """PanWatch 统一服务入口 - Web 后台 + Agent 调度"""
 
+import asyncio
 import logging
 import os
 import time
@@ -1481,6 +1482,15 @@ async def lifespan(app):
             refresh_stock_list()
 
     threading.Thread(target=refresh_stock_cache, daemon=True).start()
+
+    # 交易日历预热(判断周末/法定节假日是否开市)。拉取失败会自动降级为只判周末,
+    # 因此这里不阻塞启动,交给后台任务;之后每日 03:00 由上下文维护调度器刷新。
+    try:
+        from src.core.trading_calendar import refresh as refresh_trading_calendar
+
+        asyncio.create_task(refresh_trading_calendar())
+    except Exception as e:
+        logger.warning(f"交易日历预热调度失败(降级为只判周末): {e}")
 
     global scheduler, price_alert_scheduler, paper_trading_scheduler, context_maintenance_scheduler
     scheduler = build_scheduler()

--- a/src/core/context_scheduler.py
+++ b/src/core/context_scheduler.py
@@ -186,7 +186,12 @@ class ContextMaintenanceScheduler:
         }
 
     async def _refresh_opportunities_job(self):
-        """定时刷新机会池（候选 + 策略信号）。"""
+        """定时刷新机会池（候选 + 策略信号）。全市场休市日跳过。"""
+        from src.core.trading_calendar import any_market_trading_day
+
+        if not any_market_trading_day():
+            logger.debug("[上下文维护] 非交易日，跳过机会刷新")
+            return
         if self._refreshing:
             logger.debug("[上下文维护] 上一轮机会刷新仍在执行，跳过本轮")
             return
@@ -234,6 +239,19 @@ class ContextMaintenanceScheduler:
             outcome_days=self.outcome_retention_days,
         )
 
+    async def _refresh_trading_calendar_job(self):
+        """每日刷新 A 股交易日历。
+
+        日历只覆盖到当年年底,长跑实例跨年后会超出覆盖范围而降级为"只判周末",
+        因此每天凌晨拉一次。安排在各类盘前通知之前,保证当天判断用的是新日历。
+        """
+        from src.core.trading_calendar import refresh
+
+        try:
+            await refresh()
+        except Exception as e:  # refresh 内部已兜异常,这里只防意外
+            logger.exception(f"[上下文维护] 交易日历刷新异常: {e}")
+
     def start(self):
         self.scheduler.add_job(
             self._evaluate_job,
@@ -256,8 +274,21 @@ class ContextMaintenanceScheduler:
             coalesce=True,
             max_instances=1,
         )
-        # 机会自动刷新（北京时间 09:15 / 13:30 / 22:00）
-        for job_hour, job_minute in ((1, 15), (5, 30), (14, 0)):
+        # 交易日历每日刷新 —— 03:00,早于所有盘前通知
+        self.scheduler.add_job(
+            self._refresh_trading_calendar_job,
+            "cron",
+            hour=3,
+            minute=0,
+            jitter=120,
+            id="context_maintenance_trading_calendar",
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+        )
+        # 机会自动刷新 —— 09:15 盘前 / 13:30 午盘 / 22:00 晚间。
+        # 时间点按调度器时区(app_timezone,默认 Asia/Shanghai)解释,与 Agent cron 语义一致。
+        for job_hour, job_minute in ((9, 15), (13, 30), (22, 0)):
             self.scheduler.add_job(
                 self._refresh_opportunities_job,
                 "cron",
@@ -283,7 +314,7 @@ class ContextMaintenanceScheduler:
         from src.core.scheduler_registry import register
         register("context", self.scheduler)
         logger.info(
-            "上下文维护调度器已启动（后验评估间隔 %sh，启动补跑 +15s，快照保留 %s 天，后验保留 %s 天，机会自动刷新 01:15/05:30/14:00 UTC）",
+            "上下文维护调度器已启动（后验评估间隔 %sh，启动补跑 +15s，快照保留 %s 天，后验保留 %s 天，机会自动刷新 09:15/13:30/22:00，交易日历刷新 03:00）",
             self.eval_interval_hours,
             self.snapshot_retention_days,
             self.outcome_retention_days,

--- a/src/core/paper_trading_scheduler.py
+++ b/src/core/paper_trading_scheduler.py
@@ -7,6 +7,7 @@ import logging
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from src.core.paper_trading_engine import ENGINE
+from src.core.trading_calendar import any_market_trading_day
 from src.models.market import MARKETS, MarketCode
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,10 @@ class PaperTradingScheduler:
             self._running = False
 
     async def _premarket_job(self):
-        """盘前计划通知。"""
+        """盘前计划通知。非交易日(周末/节假日)跳过。"""
+        if not any_market_trading_day():
+            logger.debug("[模拟盘] 非交易日,跳过盘前计划通知")
+            return
         try:
             from src.core.paper_trading_notifier import send_premarket_plan
             await send_premarket_plan()
@@ -63,7 +67,10 @@ class PaperTradingScheduler:
             logger.exception(f"[模拟盘] 盘前计划通知异常: {e}")
 
     async def _summary_job(self):
-        """日终摘要通知。"""
+        """日终摘要通知。非交易日(周末/节假日)跳过。"""
+        if not any_market_trading_day():
+            logger.debug("[模拟盘] 非交易日,跳过日终摘要通知")
+            return
         try:
             from src.core.paper_trading_notifier import send_daily_summary
             await send_daily_summary()

--- a/src/core/trading_calendar.py
+++ b/src/core/trading_calendar.py
@@ -1,0 +1,156 @@
+"""交易日历:回答「这一天开不开市」。
+
+与 `MarketDef.is_trading_time()`(回答「当下是否在交易时段内」)互补 ——
+盘前计划、日终摘要这类定时任务本身就发生在交易时段之外,只能用「是不是交易日」
+来守卫,用时段判断会把它们永久拦死。
+
+数据源
+- **A 股**:akshare 交易日历(`tool_trade_date_hist_sina`),含法定节假日,权威。
+  结果缓存在内存,由 `refresh()` 更新(启动预热 + 每日凌晨刷新)。
+- **港股 / 美股**:没有等价的公开日历源,只判周末(诚实降级,不假装支持节假日)。
+
+降级原则
+拿不到日历时退回「只判周末」—— 宁可多发一条通知,也不能把交易日误判为休市。
+少发一条是遗憾,漏发一整天是事故。
+
+并发安全
+同步接口只读内存缓存,**永不发起网络请求**;网络拉取集中在 `refresh()`
+(内部 `asyncio.to_thread`)和 `refresh_blocking()`,避免阻塞事件循环。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+# A 股交易日集合;None = 尚未加载或加载失败(此时降级为只判周末)
+_CN_TRADING_DATES: frozenset[date] | None = None
+# 日历覆盖区间,用于判断查询日期是否落在可信范围内(跨年未刷新时会超出)
+_CN_RANGE: tuple[date, date] | None = None
+
+_FALLBACK_TZ = "Asia/Shanghai"
+
+
+def reset_cache() -> None:
+    """清空日历缓存(配置变更或测试用)。"""
+    global _CN_TRADING_DATES, _CN_RANGE
+    _CN_TRADING_DATES = None
+    _CN_RANGE = None
+
+
+def _fetch_cn_trading_dates() -> frozenset[date]:
+    """阻塞拉取 A 股交易日历。仅由 `refresh_blocking()` 调用。"""
+    import akshare as ak
+
+    df = ak.tool_trade_date_hist_sina()
+    out: set[date] = set()
+    for raw in df["trade_date"]:
+        if isinstance(raw, datetime):
+            out.add(raw.date())
+        elif isinstance(raw, date):
+            out.add(raw)
+        else:
+            out.add(date.fromisoformat(str(raw)[:10]))
+    return frozenset(out)
+
+
+def refresh_blocking() -> bool:
+    """同步刷新 A 股交易日历。返回是否成功;失败不抛异常(保持降级行为)。"""
+    global _CN_TRADING_DATES, _CN_RANGE
+    try:
+        dates = _fetch_cn_trading_dates()
+    except Exception as e:
+        logger.warning("[交易日历] A股日历拉取失败,降级为只判周末: %s", e)
+        return False
+    if not dates:
+        logger.warning("[交易日历] A股日历为空,降级为只判周末")
+        return False
+    _CN_TRADING_DATES = dates
+    _CN_RANGE = (min(dates), max(dates))
+    logger.info(
+        "[交易日历] A股日历已加载: %s 个交易日 (%s ~ %s)",
+        len(dates),
+        _CN_RANGE[0],
+        _CN_RANGE[1],
+    )
+    return True
+
+
+async def refresh() -> bool:
+    """异步刷新日历(走线程池,不阻塞事件循环)。"""
+    return await asyncio.to_thread(refresh_blocking)
+
+
+def _to_market_code(market):
+    """把 MarketCode / 字符串归一化为 MarketCode;无法识别返回 None。"""
+    from src.models.market import MarketCode
+
+    if isinstance(market, MarketCode):
+        return market
+    try:
+        return MarketCode(str(market).strip().upper())
+    except ValueError:
+        return None
+
+
+def _market_tz(code) -> ZoneInfo:
+    from src.models.market import MARKETS
+
+    md = MARKETS.get(code) if code else None
+    return md.get_tz() if md else ZoneInfo(_FALLBACK_TZ)
+
+
+def _now_in_market_tz(code) -> datetime:
+    """该市场时区的当前时间。独立成函数便于测试注入。"""
+    return datetime.now(_market_tz(code))
+
+
+def _resolve_date(code, d: date | datetime | None) -> date:
+    """把入参归一化为「该市场当地日期」。"""
+    if d is None:
+        return _now_in_market_tz(code).date()
+    if isinstance(d, datetime):
+        if d.tzinfo is not None:
+            d = d.astimezone(_market_tz(code))
+        return d.date()
+    return d
+
+
+def is_trading_day(market, d: date | datetime | None = None) -> bool:
+    """给定市场的某一天是否开市。
+
+    Args:
+        market: `MarketCode` 或市场码字符串(CN/HK/US)。
+        d: 目标日期;`None` 表示该市场时区的今天。带时区的 `datetime`
+           会先换算到市场时区再取日期。
+    """
+    from src.models.market import MarketCode
+
+    code = _to_market_code(market)
+    target = _resolve_date(code, d)
+
+    # 周末:三个市场都不开。零依赖、永远准确,放在最前面。
+    if target.weekday() >= 5:
+        return False
+
+    # A 股:日历已加载且覆盖该日期时按日历判(含法定节假日)。
+    if code == MarketCode.CN and _CN_TRADING_DATES and _CN_RANGE:
+        if _CN_RANGE[0] <= target <= _CN_RANGE[1]:
+            return target in _CN_TRADING_DATES
+        logger.debug("[交易日历] %s 超出A股日历覆盖范围,降级为只判周末", target)
+
+    # 港美股、日历缺失、超出覆盖范围:只判周末。
+    return True
+
+
+def any_market_trading_day(d: date | datetime | None = None) -> bool:
+    """CN/HK/US 任一为交易日即 `True`。全市场休市(如周末)返回 `False`。"""
+    from src.models.market import MarketCode
+
+    return any(
+        is_trading_day(m, d) for m in (MarketCode.CN, MarketCode.HK, MarketCode.US)
+    )

--- a/src/models/market.py
+++ b/src/models/market.py
@@ -36,8 +36,11 @@ class MarketDef:
         else:
             dt = dt.astimezone(self.get_tz())
 
-        # 周末不交易
-        if dt.weekday() >= 5:
+        # 非交易日(周末 / A股法定节假日)一律不交易。
+        # 延迟导入:trading_calendar 依赖本模块的 MarketCode/MARKETS。
+        from src.core.trading_calendar import is_trading_day
+
+        if not is_trading_day(self.code, dt.date()):
             return False
 
         current_time = dt.time()

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -1,0 +1,293 @@
+"""交易日历与非交易日通知守卫单元测试。"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.core import trading_calendar as tc
+from src.models.market import MARKETS, MarketCode
+
+# 2026 年真实日历切片:8/8 周六、8/9 周日休市;8/10 周一开市;
+# 10/1~10/8 国庆休市(其中 10/1 是周四 —— 工作日却休市,只靠周末判断抓不到)。
+_FAKE_CN_DATES = frozenset(
+    {
+        date(2026, 8, 3),
+        date(2026, 8, 4),
+        date(2026, 8, 5),
+        date(2026, 8, 6),
+        date(2026, 8, 7),
+        date(2026, 8, 10),
+        date(2026, 8, 11),
+        date(2026, 8, 12),
+        date(2026, 8, 13),
+        date(2026, 8, 14),
+        date(2026, 9, 28),
+        date(2026, 9, 29),
+        date(2026, 9, 30),
+        date(2026, 10, 9),
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_calendar():
+    """每个用例前后清空日历缓存,避免互相污染。"""
+    tc.reset_cache()
+    yield
+    tc.reset_cache()
+
+
+@pytest.fixture
+def loaded_calendar(monkeypatch):
+    """注入固定 A 股交易日历(不走网络)。"""
+    monkeypatch.setattr(tc, "_fetch_cn_trading_dates", lambda: _FAKE_CN_DATES)
+    assert tc.refresh_blocking() is True
+
+
+# ---------------------------------------------------------------------------
+# is_trading_day
+# ---------------------------------------------------------------------------
+
+
+def test_周末不是交易日_无需日历():
+    """周末即使没有日历也判为非交易日(零依赖、永远准确)。"""
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 8, 8)) is False  # 周六
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 8, 9)) is False  # 周日
+    assert tc.is_trading_day(MarketCode.HK, date(2026, 8, 8)) is False
+    assert tc.is_trading_day(MarketCode.US, date(2026, 8, 9)) is False
+
+
+def test_工作日是交易日(loaded_calendar):
+    """日历已加载时,普通工作日判为交易日。"""
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 8, 10)) is True  # 周一
+
+
+def test_法定节假日不是交易日(loaded_calendar):
+    """国庆(10/1 周四)靠日历识别为休市 —— 周末判断抓不到这一类。"""
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 10, 1)) is False
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 10, 2)) is False
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 10, 9)) is True  # 节后首个交易日
+
+
+def test_日历缺失时降级为只判周末():
+    """拿不到日历时工作日一律视为交易日 —— 宁可多跑,不可漏发一整天。"""
+    assert tc._CN_TRADING_DATES is None
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 10, 1)) is True  # 降级:识别不出国庆
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 8, 8)) is False  # 但周末照样拦住
+
+
+def test_超出日历覆盖范围时降级为只判周末(loaded_calendar):
+    """查询日期超出日历区间(如跨年未刷新)时降级,不误判交易日为休市。"""
+    assert tc.is_trading_day(MarketCode.CN, date(2027, 3, 1)) is True  # 2027-03-01 是周一
+
+
+def test_港美股无日历源_只判周末(loaded_calendar):
+    """A 股日历不套用到港美股(节假日不同),它们只判周末。"""
+    # 10/1 对港股/美股不是中国法定假日,不应被 A 股日历误伤
+    assert tc.is_trading_day(MarketCode.US, date(2026, 10, 1)) is True
+    assert tc.is_trading_day(MarketCode.HK, date(2026, 10, 1)) is True
+
+
+def test_接受字符串市场码与datetime(loaded_calendar):
+    """market 接受字符串,日期接受 datetime(按市场时区归到当地日)。"""
+    assert tc.is_trading_day("CN", date(2026, 10, 1)) is False
+    dt = datetime(2026, 10, 1, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    assert tc.is_trading_day("CN", dt) is False
+
+
+def test_any_market_trading_day(loaded_calendar):
+    """周末三市场全休 → False;工作日至少一个开市 → True。"""
+    assert tc.any_market_trading_day(date(2026, 8, 8)) is False  # 周六
+    assert tc.any_market_trading_day(date(2026, 8, 10)) is True  # 周一
+    # A股国庆休市但美股开市 → 仍为 True
+    assert tc.any_market_trading_day(date(2026, 10, 1)) is True
+
+
+def test_刷新失败不抛异常且保持降级(monkeypatch):
+    """日历拉取抛异常时 refresh 返回 False,缓存保持空,行为降级而非崩溃。"""
+
+    def _boom():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(tc, "_fetch_cn_trading_dates", _boom)
+    assert tc.refresh_blocking() is False
+    assert tc._CN_TRADING_DATES is None
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 8, 10)) is True
+
+
+def test_异步刷新不阻塞(monkeypatch):
+    """refresh() 走 to_thread,结果与同步版一致。"""
+    monkeypatch.setattr(tc, "_fetch_cn_trading_dates", lambda: _FAKE_CN_DATES)
+    assert asyncio.run(tc.refresh()) is True
+    assert tc.is_trading_day(MarketCode.CN, date(2026, 10, 1)) is False
+
+
+# ---------------------------------------------------------------------------
+# is_trading_time 复用交易日历(一处修复,全线受益)
+# ---------------------------------------------------------------------------
+
+
+def test_交易时段判断在法定节假日返回False(loaded_calendar):
+    """节假日的 10:00 处在时段区间内,但不是交易日 → 非交易时间。"""
+    md = MARKETS[MarketCode.CN]
+    holiday_10am = datetime(2026, 10, 1, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    assert md.is_trading_time(holiday_10am) is False
+
+
+def test_交易时段判断在正常交易日返回True(loaded_calendar):
+    """交易日 10:00 在时段内 → 交易中。"""
+    md = MARKETS[MarketCode.CN]
+    trading_10am = datetime(2026, 8, 10, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    assert md.is_trading_time(trading_10am) is True
+
+
+def test_交易日的非时段时间返回False(loaded_calendar):
+    """交易日的 08:00 不在时段内 → 非交易时间。"""
+    md = MARKETS[MarketCode.CN]
+    before_open = datetime(2026, 8, 10, 8, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    assert md.is_trading_time(before_open) is False
+
+
+# ---------------------------------------------------------------------------
+# 模拟盘定时通知的非交易日守卫(用户报告的 bug)
+# ---------------------------------------------------------------------------
+
+
+def _patch_notifiers(monkeypatch) -> dict[str, int]:
+    """把两个通知函数替换成计数器,用于断言是否被调用。"""
+    calls = {"premarket": 0, "summary": 0}
+
+    async def _fake_premarket():
+        calls["premarket"] += 1
+
+    async def _fake_summary():
+        calls["summary"] += 1
+
+    monkeypatch.setattr(
+        "src.core.paper_trading_notifier.send_premarket_plan", _fake_premarket
+    )
+    monkeypatch.setattr(
+        "src.core.paper_trading_notifier.send_daily_summary", _fake_summary
+    )
+    return calls
+
+
+def test_周末不发盘前计划和日终摘要(monkeypatch):
+    """周末两条模拟盘定时通知都必须跳过 —— 这是用户报告的 bug。"""
+    from src.core.paper_trading_scheduler import PaperTradingScheduler
+
+    calls = _patch_notifiers(monkeypatch)
+    saturday = datetime(2026, 8, 8, 9, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: saturday)
+
+    sched = PaperTradingScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched._premarket_job())
+    asyncio.run(sched._summary_job())
+
+    assert calls == {"premarket": 0, "summary": 0}
+
+
+def test_法定节假日不发盘前计划和日终摘要(monkeypatch, loaded_calendar):
+    """A股国庆期间(美股也休市的那几天)同样跳过。"""
+    from src.core.paper_trading_scheduler import PaperTradingScheduler
+
+    calls = _patch_notifiers(monkeypatch)
+    # 10/3 是周六:三市场全休 → 必须跳过
+    holiday = datetime(2026, 10, 3, 9, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: holiday)
+
+    sched = PaperTradingScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched._premarket_job())
+    asyncio.run(sched._summary_job())
+
+    assert calls == {"premarket": 0, "summary": 0}
+
+
+def test_交易日照常发盘前计划和日终摘要(monkeypatch, loaded_calendar):
+    """交易日不受守卫影响,通知照常发送。"""
+    from src.core.paper_trading_scheduler import PaperTradingScheduler
+
+    calls = _patch_notifiers(monkeypatch)
+    monday = datetime(2026, 8, 10, 9, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: monday)
+
+    sched = PaperTradingScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched._premarket_job())
+    asyncio.run(sched._summary_job())
+
+    assert calls == {"premarket": 1, "summary": 1}
+
+
+# ---------------------------------------------------------------------------
+# 机会刷新的非交易日守卫(周末重算全市场只是白烧资源)
+# ---------------------------------------------------------------------------
+
+
+def test_周末跳过机会刷新(monkeypatch):
+    """周末不重算机会池 —— 行情没变,扫全市场纯属浪费。"""
+    from src.core.context_scheduler import ContextMaintenanceScheduler
+
+    calls = {"n": 0}
+
+    def _fake_refresh(**kwargs):
+        calls["n"] += 1
+        return {"count": 0}
+
+    monkeypatch.setattr(
+        "src.core.context_scheduler.refresh_strategy_signals", _fake_refresh
+    )
+    saturday = datetime(2026, 8, 8, 9, 15, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: saturday)
+
+    sched = ContextMaintenanceScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched._refresh_opportunities_job())
+
+    assert calls["n"] == 0
+
+
+def test_交易日照常刷新机会(monkeypatch, loaded_calendar):
+    """交易日机会刷新不受守卫影响。"""
+    from src.core.context_scheduler import ContextMaintenanceScheduler
+
+    calls = {"n": 0}
+
+    def _fake_refresh(**kwargs):
+        calls["n"] += 1
+        return {"count": 3, "snapshot_date": "2026-08-10"}
+
+    monkeypatch.setattr(
+        "src.core.context_scheduler.refresh_strategy_signals", _fake_refresh
+    )
+    monday = datetime(2026, 8, 10, 9, 15, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: monday)
+
+    sched = ContextMaintenanceScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched._refresh_opportunities_job())
+
+    assert calls["n"] == 1
+
+
+def test_手动刷新机会不受非交易日守卫影响(monkeypatch):
+    """手动触发是用户显式意图,周末也必须能跑。"""
+    from src.core.context_scheduler import ContextMaintenanceScheduler
+
+    calls = {"n": 0}
+
+    def _fake_refresh(**kwargs):
+        calls["n"] += 1
+        return {"count": 1}
+
+    monkeypatch.setattr(
+        "src.core.context_scheduler.refresh_strategy_signals", _fake_refresh
+    )
+    saturday = datetime(2026, 8, 8, 9, 15, tzinfo=ZoneInfo("Asia/Shanghai"))
+    monkeypatch.setattr(tc, "_now_in_market_tz", lambda code: saturday)
+
+    sched = ContextMaintenanceScheduler(timezone="Asia/Shanghai")
+    asyncio.run(sched.refresh_opportunities_once())
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## 问题

模拟盘「盘前计划(09:00)」「日终摘要(15:30)」两个 cron job **既无 `day_of_week` 限制也无交易日守卫**,周末照发通知。这两个 job 时间点硬编码在代码里、用户改不了,所以必须内置正确行为。

> Agent 侧默认 cron 已带 `1-5`,且 cron 是用户显式配置 —— 不加隐式守卫,避免"我配了每天却不跑"变成新的困惑。

## 根因

`paper_trading_scheduler.py` 的两个 job 直接 `cron(hour=9)` / `cron(hour=15, minute=30)`,通知函数 `send_premarket_plan()` / `send_daily_summary()` 内部也没有任何日期判断。

而现有的 `MarketDef.is_trading_time()` 回答的是"**当下是否在交易时段内**",盘前/盘后通知本身就发生在时段之外,用它守卫会把这两个 job 永久拦死 —— 缺的是"**这一天开不开市**"这个语义。

## 修复

新增 `src/core/trading_calendar.py` 作为交易日判断的单一真相源:

- **A 股**:akshare 交易日历(`tool_trade_date_hist_sina`,含法定节假日),内存缓存,启动预热 + 每日 03:00 刷新(日历只覆盖到当年底,跨年需要重拉)
- **港股/美股**:没有等价的公开日历源,只判周末(诚实降级,不假装支持节假日)
- **降级原则**:拿不到日历时退回"只判周末" —— 少发一条通知是遗憾,漏发一整天是事故
- **并发安全**:同步接口只读内存缓存、永不发起网络请求;拉取集中在 `to_thread`,不阻塞事件循环

## 同族问题(一并修掉)

| 问题 | 影响 |
|---|---|
| `is_trading_time()` 不认法定节假日 | 国庆/春节 `weekday<5`,**模拟盘扫描每 60s 照跑、可能按陈旧价开平仓**。改为复用交易日历后,13 个调用点(K线缓存 TTL / 价格提醒 / 盘中监测 / 前端交易中状态…)一并受益 |
| 机会自动刷新时区错位 | 时间点按 UTC 写成 `(1,15)/(5,30)/(14,0)`,而调度器实际跑在 `app_timezone`(Asia/Shanghai)→ 注释与启动日志宣称的 09:15/13:30/22:00 实际在**北京 01:15/05:30/14:00** 执行。改为按调度器时区的 09:15/13:30/22:00 |
| 机会刷新在周末照跑 | 行情没变却重算全市场(扫 80 股 + 60 只 K线),纯属白烧资源。加非交易日守卫;**手动触发不受影响** |

## 验证

`tests/test_trading_calendar.py` 19 项:周末 / 法定节假日 / 日历缺失降级 / 超覆盖范围降级 / 港美股不被 A 股日历误伤 / 字符串与 datetime 入参 / 刷新失败不崩 / 时段判断 / 两条模拟盘通知守卫 / 机会刷新守卫 / 手动触发豁免。

- 全量 **481 passed**(pre-push hook 已验证)
- 真实日历端到端核对:2026-08-15/16 周末休市、10-01~10-02 国庆休市、10-09 节后开市、02-17 春节休市 ✅