### PR TITLE
test(marketdata): events 用例日期改为相对今天,消除到期爆炸

### DIFF
--- a/packages/marketdata/tests/test_events_vendor.py
+++ b/packages/marketdata/tests/test_events_vendor.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 import marketdata.vendors.events as ev
 from marketdata.symbol import Symbol
 from marketdata.types import EventItem
@@ -6,31 +8,39 @@ from marketdata.types import EventItem
 def test_events_parses_and_filters(monkeypatch):
     # 东财 ann 响应结构与字段名以 src/collectors/events_collector.py 的 _parse_item 实际读取为准:
     # data.list[].{art_code, title, notice_date, columns[].column_name, codes[].stock_code}
+    #
+    # 日期相对「今天」生成:since_days 窗口是滚动的,写死日期的用例会在跨过窗口那天
+    # 突然全被过滤掉而失败(曾发生)。
+    recent = date.today() - timedelta(days=2)
+    older = date.today() - timedelta(days=4)
+    recent_code = f"AN{recent:%Y%m%d}0002"
+    older_code = f"AN{older:%Y%m%d}0001"
+
     payload = {
         "success": True,
         "data": {
             "list": [
                 # 较新、"回购" -> event_type=repurchase, importance=2
                 {
-                    "art_code": "AN202607120002",
+                    "art_code": recent_code,
                     "title": "贵州茅台股份有限公司关于回购股份的公告",
-                    "notice_date": "2026-07-12 10:00:00",
+                    "notice_date": f"{recent:%Y-%m-%d} 10:00:00",
                     "columns": [{"column_name": "临时公告"}],
                     "codes": [{"stock_code": "600519"}],
                 },
                 # 较旧、"重大资产重组" -> event_type=restructuring, importance=3
                 {
-                    "art_code": "AN202607100001",
+                    "art_code": older_code,
                     "title": "贵州茅台股份有限公司关于重大资产重组的公告",
-                    "notice_date": "2026-07-10 09:00:00",
+                    "notice_date": f"{older:%Y-%m-%d} 09:00:00",
                     "columns": [{"column_name": "重大事项"}],
                     "codes": [{"stock_code": "600519"}],
                 },
                 # 与第一条重复的 art_code -> 应被去重
                 {
-                    "art_code": "AN202607120002",
+                    "art_code": recent_code,
                     "title": "贵州茅台股份有限公司关于回购股份的公告(重复)",
-                    "notice_date": "2026-07-12 10:00:00",
+                    "notice_date": f"{recent:%Y-%m-%d} 10:00:00",
                     "columns": [{"column_name": "临时公告"}],
                     "codes": [{"stock_code": "600519"}],
                 },
@@ -47,15 +57,18 @@ def test_events_parses_and_filters(monkeypatch):
     # 去重生效:3 条输入 -> 2 条唯一 (source, external_id)
     assert len(out) == 2
 
-    # 排序:按 (publish_time, importance) 降序 -> 07-12 的回购公告排第一
-    assert out[0].external_id == "AN202607120002"
+    # 排序:按 (publish_time, importance) 降序 -> 较新的回购公告排第一
+    assert out[0].external_id == recent_code
     assert out[0].event_type == "repurchase"
     assert out[0].importance == 2
     assert out[0].symbols == ["600519"]
     assert out[0].source == "eastmoney"
-    assert out[0].url == "https://data.eastmoney.com/notices/detail/600519/AN202607120002.html"
+    assert (
+        out[0].url
+        == f"https://data.eastmoney.com/notices/detail/600519/{recent_code}.html"
+    )
 
-    assert out[1].external_id == "AN202607100001"
+    assert out[1].external_id == older_code
     assert out[1].event_type == "restructuring"
     assert out[1].importance == 3
 


### PR DESCRIPTION
## 问题

`0.10.2` 的 release CI 在 **Run marketdata package tests** 步骤中断:

```
FAILED packages/marketdata/tests/test_events_vendor.py::test_events_parses_and_filters
assert 0 == 2
 +  where 0 = len([])
1 failed, 187 passed
```

与该 tag 的代码改动无关 —— 这是一个**到期爆炸**的用例。

## 根因

用例把 `notice_date` 写死成 `2026-07-12` / `2026-07-10`,却用**滚动窗口** `since_days=30` 取数。窗口随日期前移,跨过临界那天(2026-08-12,距 07-12 已 31 天)两条 payload 全部被过滤,返回空列表。

昨天(8/11,刚好 30 天)还能过 —— 属于典型的"某天早上突然红了,谁都没改代码"。

## 修复

日期改为按 `date.today()` 相对生成(`recent = -2d` / `older = -4d`),`art_code` 与 URL 断言随之动态化。断言语义(去重、排序、`event_type`、`importance`、`symbols`、`source`、`url`)完全不变。

## 同类扫描

- marketdata 其余用例的硬编码日期都是**显式传入 `date` 参数**(龙虎榜 / 北向 / 分红 / 财报),不依赖滚动窗口 → 不会到期
- `test_news.py` 的 `since_hours` 用例**显式注入 `now`**(且有一条专门验证"不传 now 就不做时间过滤")→ 设计上已免疫
- `tests/test_events_routing.py` 的 `since_days` 只是 stub 签名默认值,不解析日期

只有这一处。

## 验证

按 CI 的两步跑:`pytest tests/ -x -q` → **481 passed**;`pytest packages/marketdata/tests -q` → **188 passed**(修复前是 1 failed + 187)。