### PR TITLE
fix(tradingagents): auto_trigger 误读不存在的 AgentConfig.raw_config,改为 config

### DIFF
--- a/src/agents/tradingagents/auto_trigger.py
+++ b/src/agents/tradingagents/auto_trigger.py
@@ -30,7 +30,7 @@ DEFAULT_COOLDOWN_HOURS = 24
 
 
 def _read_auto_trigger_config(db: Session) -> dict | None:
-    """从 AgentConfig.raw_config 读 auto_trigger 配置。
+    """从 AgentConfig.config 读 auto_trigger 配置。
 
     Returns:
         {
@@ -42,7 +42,7 @@ def _read_auto_trigger_config(db: Session) -> dict | None:
     agent = db.query(AgentConfig).filter(AgentConfig.name == "tradingagents").first()
     if not agent:
         return None
-    raw = agent.raw_config or {}
+    raw = agent.config or {}
     auto = raw.get("auto_trigger") or {}
     if not auto.get("enabled"):
         return None
@@ -69,7 +69,7 @@ def _within_cooldown(db: Session, stock_symbol: str, cooldown_hours: int) -> boo
 
 
 def _budget_allows(db: Session) -> bool:
-    """检查月度预算是否还有余量。预算从 tradingagents 的 raw_config.monthly_budget_usd 读。"""
+    """检查月度预算是否还有余量。预算从 tradingagents 的 config.monthly_budget_usd 读。"""
     try:
         from src.agents.tradingagents.cost_tracker import check_budget
     except ImportError:
@@ -78,7 +78,7 @@ def _budget_allows(db: Session) -> bool:
     agent = db.query(AgentConfig).filter(AgentConfig.name == "tradingagents").first()
     if not agent:
         return True
-    raw = agent.raw_config or {}
+    raw = agent.config or {}
     budget = float(raw.get("monthly_budget_usd") or 0.0)
     if budget <= 0:
         return True  # 没设上限 = 不限制

--- a/tests/test_tradingagents_auto_trigger.py
+++ b/tests/test_tradingagents_auto_trigger.py
@@ -7,11 +7,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agents.tradingagents import auto_trigger
+from src.web.models import AgentConfig
 
 
-def _make_agent(raw_config: dict):
-    agent = MagicMock()
-    agent.raw_config = raw_config
+def _make_agent(config: dict):
+    agent = MagicMock(spec=AgentConfig)
+    agent.config = config
     return agent
 
 


### PR DESCRIPTION
AgentConfig 模型的 JSON 配置列名为 config(src/web/models.py), auto_trigger 中的 agent.raw_config 在运行时抛
AttributeError: 'AgentConfig' object has no attribute 'raw_config' 导致盘中急涨/急跌联动 TradingAgents 深度分析永远无法触发
(_read_auto_trigger_config / _budget_allows 均会失败)。

- _read_auto_trigger_config 与 _budget_allows 改读 agent.config
- 单测 _make_agent 改用 MagicMock(spec=AgentConfig) + 真实字段 config, 从根上杜绝字段名回归(裸 MagicMock 任意属性都存在,此前测不出该 bug)