### PR TITLE
fix: MCP 日志保留期清理任务注册失败（scheduler.add_job → scheduler.scheduler.add_job）

### DIFF
--- a/server.py
+++ b/server.py
@@ -1529,7 +1529,7 @@ async def lifespan(app):
     try:
         from src.web.api.mcp import prune_mcp_logs
 
-        scheduler.add_job(
+        scheduler.scheduler.add_job(
             prune_mcp_logs,
             "cron",
             hour=4,


### PR DESCRIPTION
## 问题

启动日志报错：

```
ERROR [server] MCP 日志清理任务注册失败: 'AgentScheduler' object has no attribute 'add_job'
```

## 根因

`server.py` 的 `lifespan()` 里，`scheduler` 是 `build_scheduler()` 返回的 `AgentScheduler` 实例。`AgentScheduler` 内部包装了 APScheduler 的 `AsyncIOScheduler`（存为 `self.scheduler`），但自身并没有暴露 `add_job` 方法（只有 `register()` / `start()` / `shutdown()` / `trigger_now()`）。

因此在注册「MCP 调用日志保留期清理」定时任务时，调用了不存在的 `scheduler.add_job(...)`，抛出 `AttributeError`。

## 影响

- `prune_mcp_logs` 全仓库仅此一处调用点 → 清理任务**从未被注册、从未执行**
- `MCPCallLog` 在每次 MCP 工具调用时都会写库 → 日志表会无限累积，长期占用数据库体积
- 盯盘 / TradingAgents 分析 / 价格提醒 / 推送 / 模拟盘等核心功能不受影响（其余调度器均正常启动）

## 修复

将调用路由到内部包装的 `AsyncIOScheduler`：

```diff
-        scheduler.add_job(
+        scheduler.scheduler.add_job(
             prune_mcp_logs,
             "cron",
             hour=4,
             minute=0,
             id="mcp_log_retention",
             replace_existing=True,
         )
```

与同类调度器（价格提醒 / 模拟盘 / 上下文维护各自在类内部 `self.scheduler.add_job(...)`）的用法保持一致。