### PR TITLE
修复助手页面外层滚动溢出

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,6 +76,7 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 function App() {
   const { mode, setMode } = useTheme()
   const location = useLocation()
+  const isAssistantRoute = location.pathname === '/assistant' || location.pathname.startsWith('/assistant/')
   const [version, setVersion] = useState('')
   const [logsOpen, setLogsOpen] = useState(false)
   const [selfCheckOpen, setSelfCheckOpen] = useState(false)
@@ -121,7 +122,11 @@ function App() {
 
   return (
     <RequireAuth>
-    <div className="min-h-screen pb-16 md:pb-0 relative overflow-x-clip bg-background">
+    <div
+      className={isAssistantRoute
+        ? 'relative flex h-dvh flex-col overflow-hidden bg-background pb-16 md:pb-0'
+        : 'min-h-screen pb-16 md:pb-0 relative overflow-x-clip bg-background'}
+    >
       <AmbientBackground />
       {/* Desktop Floating Nav */}
       <div className="sticky top-0 z-50 px-4 md:px-6 pt-3 md:pt-4 pb-2 hidden md:block">
@@ -257,7 +262,9 @@ function App() {
       </nav>
 
       {/* Content */}
-      <main className="px-4 md:px-6 py-4 md:py-6 w-full">
+      <main
+        className={`${isAssistantRoute ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : ''} px-4 md:px-6 py-4 md:py-6 w-full`}
+      >
         <AssistantOpenBridge />
         <Routes>
           <Route path="/" element={<DashboardPage />} />

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -663,7 +663,7 @@ export default function ChatWidget({
       <div
         data-testid={embedded ? 'assistant-shell' : undefined}
         className={embedded
-        ? 'relative flex h-[calc(100dvh-12rem)] min-h-0 w-full overflow-hidden rounded-2xl border border-border/60 bg-card shadow-sm md:h-[calc(100dvh-8rem)]'
+        ? 'relative flex h-full min-h-0 w-full overflow-hidden rounded-2xl border border-border/60 bg-card shadow-sm'
         : 'fixed bottom-0 right-0 z-50 flex h-full w-full flex-col overflow-hidden bg-background shadow-2xl md:bottom-5 md:right-5 md:h-[600px] md:w-[420px] md:rounded-xl md:border md:border-border/60'}>
         {embedded && (
           <div className="hidden w-64 shrink-0 md:flex">

--- a/frontend/tests/assistant/ChatWidgetLayout.test.tsx
+++ b/frontend/tests/assistant/ChatWidgetLayout.test.tsx
@@ -96,7 +96,7 @@ describe('ChatWidget layout', () => {
     const composer = screen.getByTestId('assistant-composer')
 
     expect(shell.className).toContain('min-h-0')
-    expect(shell.className).toContain('h-[calc(100dvh-8rem)]')
+    expect(shell.className).toContain('h-full')
     expect(messageList.className).toContain('min-h-0')
     expect(messageList.className).toContain('overflow-y-auto')
     expect(composer.className).toContain('shrink-0')


### PR DESCRIPTION
## 改动\n- 助手路由使用视口高度布局并禁止页面级滚动，避免导航、页面内边距与助手高度叠加导致右侧滚动条。\n- 助手容器改为填充主内容区高度，继续仅由消息列表承担内容滚动。\n- 更新布局回归测试，确保 composer 固定在底部。\n\n## 验证\n- pnpm vitest run\n- pnpm build\n- 已在本地浏览器确认页面外层滚动条消失。