### PR TITLE
修复 CI 中上下文测试对本地 AI 配置的依赖

### DIFF
--- a/tests/test_assistant_context_engine.py
+++ b/tests/test_assistant_context_engine.py
@@ -125,8 +125,14 @@ def test_service_exposes_context_usage_and_latest_summary_for_the_ui():
     engine.dispose()
 
 
-def test_prepare_context_includes_durable_tool_findings_as_trusted_facts():
+def test_prepare_context_includes_durable_tool_findings_as_trusted_facts(monkeypatch):
+    from pan_agent import ExtractiveContextSummarizer
     engine, session, service = _service()
+    monkeypatch.setattr(
+        service,
+        "build_context_summarizer",
+        lambda: ExtractiveContextSummarizer(),
+    )
     conversation = service.create_conversation(CreateConversationCommand())
     service.record_user_message(conversation.id, "删除它")
     task = service.create_task(conversation.id, 1)


### PR DESCRIPTION
## 变更\n- 为仅验证持久化工具记录的上下文测试注入确定性摘要器\n- 避免测试构造真实 OpenAI 客户端，保证无 AI 凭证的 CI 环境可重复运行\n\n## 验证\n- 后端：704 passed, 1 skipped\n- marketdata：188 passed